### PR TITLE
test: add tests for core pipeline modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,73 @@
+"""Shared fixtures for pidcast tests."""
+
+import pytest
+
+from pidcast.config import VideoInfo
+from pidcast.model_selector import ModelConfig, ModelsConfig
+
+
+@pytest.fixture
+def sample_video_info():
+    """Reusable VideoInfo for tests."""
+    return VideoInfo(
+        title="How to Build Great Software",
+        webpage_url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        channel="Tech Channel",
+        uploader="Tech Channel",
+        duration=3600,
+        duration_string="1:00:00",
+        view_count=100000,
+        upload_date="20240101",
+        description="A talk about software engineering.",
+    )
+
+
+@pytest.fixture
+def sample_model_config():
+    """Single ModelConfig for tests."""
+    return ModelConfig(
+        name="test-model",
+        display_name="Test Model",
+        provider="groq",
+        context_window=131072,
+        pricing_input=0.15,
+        pricing_output=0.60,
+        rpm=30,
+        rpd=1000,
+        tpm=8000,
+        tpd=200000,
+    )
+
+
+@pytest.fixture
+def sample_models_config():
+    """Full ModelsConfig with fallback chain."""
+    large = ModelConfig(
+        name="large-model",
+        display_name="Large Model",
+        provider="groq",
+        context_window=131072,
+        pricing_input=0.15,
+        pricing_output=0.60,
+        rpm=30,
+        rpd=1000,
+        tpm=8000,
+        tpd=200000,
+    )
+    small = ModelConfig(
+        name="small-model",
+        display_name="Small Model",
+        provider="groq",
+        context_window=32768,
+        pricing_input=0.05,
+        pricing_output=0.08,
+        rpm=30,
+        rpd=14400,
+        tpm=6000,
+        tpd=500000,
+    )
+    return ModelsConfig(
+        default_model="large-model",
+        fallback_chain=["large-model", "small-model"],
+        models={"large-model": large, "small-model": small},
+    )

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,0 +1,208 @@
+"""Tests for pidcast.chunking module."""
+
+from pidcast.chunking import (
+    CHAR_TO_TOKEN_RATIO,
+    CHUNK_MIN_CHARS,
+    TranscriptChunk,
+    chunk_transcript,
+    estimate_tokens,
+    find_semantic_boundary,
+    format_chunk_for_analysis,
+    format_chunks_for_synthesis,
+    needs_chunking,
+)
+
+# ============================================================================
+# estimate_tokens
+# ============================================================================
+
+
+class TestEstimateTokens:
+    def test_empty_string(self):
+        assert estimate_tokens("") == 0
+
+    def test_normal_text(self):
+        text = "a" * 400
+        assert estimate_tokens(text) == 400 // CHAR_TO_TOKEN_RATIO
+
+    def test_short_text(self):
+        assert estimate_tokens("hi") == 0  # 2 // 4 = 0
+
+    def test_non_ascii(self):
+        text = "日本語テスト" * 100
+        result = estimate_tokens(text)
+        assert result > 0
+
+
+# ============================================================================
+# needs_chunking
+# ============================================================================
+
+
+class TestNeedsChunking:
+    def test_below_threshold(self):
+        text = "a" * 100
+        assert needs_chunking(text, max_tokens=1000) is False
+
+    def test_above_threshold(self):
+        # 4001 chars = 1000 tokens, exceeds max_tokens=999
+        text = "a" * 4000
+        assert needs_chunking(text, max_tokens=999) is True
+
+    def test_exactly_at_threshold(self):
+        text = "a" * 4000  # 1000 tokens
+        assert needs_chunking(text, max_tokens=1000) is False
+
+    def test_empty_string(self):
+        assert needs_chunking("", max_tokens=100) is False
+
+
+# ============================================================================
+# find_semantic_boundary
+# ============================================================================
+
+
+class TestFindSemanticBoundary:
+    def test_paragraph_break_preferred(self):
+        text = "First paragraph.\n\nSecond paragraph. Some sentence here."
+        target = 20
+        result = find_semantic_boundary(text, target, search_range=50)
+        # Should find the \n\n boundary
+        assert text[result - 1] == "\n" or text[result : result + 1] != "\n"
+
+    def test_sentence_boundary_when_no_paragraphs(self):
+        text = "First sentence. Second sentence. Third sentence."
+        target = 20
+        result = find_semantic_boundary(text, target, search_range=50)
+        # Should land after a ". " boundary
+        assert result > 0
+
+    def test_newline_when_no_sentences(self):
+        text = "line one\nline two\nline three"
+        target = 12
+        result = find_semantic_boundary(text, target, search_range=50)
+        assert result > 0
+
+    def test_word_boundary_fallback(self):
+        text = "word1 word2 word3 word4"
+        target = 10
+        result = find_semantic_boundary(text, target, search_range=50)
+        assert result > 0
+
+    def test_no_boundaries_returns_target(self):
+        text = "abcdefghijklmnop"
+        target = 8
+        result = find_semantic_boundary(text, target, search_range=50)
+        assert result == target
+
+    def test_boundary_near_start(self):
+        text = "\n\nSome text after paragraph break."
+        result = find_semantic_boundary(text, target_pos=0, search_range=10)
+        assert result >= 0
+
+
+# ============================================================================
+# chunk_transcript
+# ============================================================================
+
+
+class TestChunkTranscript:
+    def test_short_transcript_single_chunk(self):
+        text = "Short transcript content." * 50  # well under default target
+        chunks = chunk_transcript(text, target_tokens=50000)
+        assert len(chunks) == 1
+        assert chunks[0].index == 0
+        assert chunks[0].total_chunks == 1
+
+    def test_long_transcript_multiple_chunks(self):
+        # Create text that needs splitting: target 100 tokens = 400 chars
+        text = ("This is a sentence. " * 50 + "\n\n") * 10  # ~10k chars
+        chunks = chunk_transcript(text, target_tokens=500, overlap_tokens=10)
+        assert len(chunks) > 1
+        for i, chunk in enumerate(chunks):
+            assert chunk.index == i
+            assert chunk.total_chunks == len(chunks)
+
+    def test_chunks_cover_full_text(self):
+        text = "Word " * 2000  # 10k chars
+        chunks = chunk_transcript(text, target_tokens=500, overlap_tokens=0)
+        # First chunk starts at 0, last chunk ends at text length
+        assert chunks[0].char_start == 0
+        assert chunks[-1].char_end == len(text)
+
+    def test_chunk_min_size_respected(self):
+        text = "a" * (CHUNK_MIN_CHARS + 100)
+        chunks = chunk_transcript(text, target_tokens=10, overlap_tokens=0)
+        for chunk in chunks:
+            assert len(chunk.text) >= CHUNK_MIN_CHARS or chunk == chunks[-1]
+
+    def test_total_chunks_updated(self):
+        text = ("Sentence one. " * 100 + "\n\n") * 5
+        chunks = chunk_transcript(text, target_tokens=200, overlap_tokens=10)
+        for chunk in chunks:
+            assert chunk.total_chunks == len(chunks)
+
+    def test_empty_transcript(self):
+        chunks = chunk_transcript("", target_tokens=1000)
+        assert len(chunks) == 0
+
+
+# ============================================================================
+# format_chunk_for_analysis
+# ============================================================================
+
+
+class TestFormatChunkForAnalysis:
+    def test_basic_formatting(self):
+        chunk = TranscriptChunk(
+            index=0,
+            total_chunks=3,
+            text="Some transcript text",
+            char_start=0,
+            char_end=20,
+            estimated_tokens=5,
+        )
+        result = format_chunk_for_analysis(chunk, "My Video Title")
+        assert result["transcript"] == "Some transcript text"
+        assert result["title"] == "My Video Title"
+        assert result["chunk_num"] == "1"
+        assert result["total_chunks"] == "3"
+
+    def test_values_are_strings(self):
+        chunk = TranscriptChunk(
+            index=4,
+            total_chunks=10,
+            text="text",
+            char_start=0,
+            char_end=4,
+            estimated_tokens=1,
+        )
+        result = format_chunk_for_analysis(chunk, "Title")
+        assert isinstance(result["chunk_num"], str)
+        assert isinstance(result["total_chunks"], str)
+
+
+# ============================================================================
+# format_chunks_for_synthesis
+# ============================================================================
+
+
+class TestFormatChunksForSynthesis:
+    def test_basic_formatting(self):
+        results = ["Analysis of chunk 1", "Analysis of chunk 2"]
+        output = format_chunks_for_synthesis(results, "My Video", "1:00:00")
+        assert "# Video: My Video" in output
+        assert "# Duration: 1:00:00" in output
+        assert "# Analyzed in 2 chunks" in output
+        assert "## Chunk 1 of 2" in output
+        assert "## Chunk 2 of 2" in output
+        assert "Analysis of chunk 1" in output
+
+    def test_single_chunk(self):
+        output = format_chunks_for_synthesis(["Only result"], "Title", "5:00")
+        assert "# Analyzed in 1 chunks" in output
+        assert "## Chunk 1 of 1" in output
+
+    def test_strips_whitespace(self):
+        output = format_chunks_for_synthesis(["  padded  "], "T", "0:00")
+        assert "padded" in output

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,169 @@
+"""Tests for pidcast.markdown module."""
+
+import pytest
+
+from pidcast.markdown import (
+    create_analysis_markdown_file,
+    create_markdown_file,
+    format_yaml_front_matter,
+)
+
+# ============================================================================
+# format_yaml_front_matter
+# ============================================================================
+
+
+class TestFormatYamlFrontMatter:
+    def test_simple_values(self):
+        result = format_yaml_front_matter({"title": "Hello", "count": 42})
+        assert result.startswith("---")
+        assert result.endswith("---")
+        assert "title: Hello" in result
+        assert "count: 42" in result
+
+    def test_value_with_colon_quoted(self):
+        result = format_yaml_front_matter({"title": "Part 1: The Beginning"})
+        assert 'title: "Part 1: The Beginning"' in result
+
+    def test_value_with_hash_quoted(self):
+        result = format_yaml_front_matter({"note": "issue #42"})
+        assert 'note: "issue #42"' in result
+
+    def test_value_starting_with_star(self):
+        result = format_yaml_front_matter({"note": "*bold text*"})
+        assert 'note: "*bold text*"' in result
+
+    def test_list_values(self):
+        result = format_yaml_front_matter({"tags": ["a", "b", "c"]})
+        assert "tags: ['a', 'b', 'c']" in result
+
+    def test_empty_dict(self):
+        result = format_yaml_front_matter({})
+        assert result == "---\n---"
+
+    def test_boolean_value(self):
+        result = format_yaml_front_matter({"active": True})
+        assert "active: True" in result
+
+
+# ============================================================================
+# create_markdown_file
+# ============================================================================
+
+
+class TestCreateMarkdownFile:
+    def test_creates_file(self, tmp_path, sample_video_info):
+        transcript = tmp_path / "transcript.txt"
+        transcript.write_text("This is the transcript content.")
+        output = tmp_path / "output.md"
+
+        result = create_markdown_file(output, transcript, sample_video_info)
+        assert result is True
+        assert output.exists()
+
+        content = output.read_text()
+        assert content.startswith("---")
+        assert "This is the transcript content." in content
+        assert "How to Build Great Software" in content
+
+    def test_missing_transcript(self, tmp_path, sample_video_info):
+        output = tmp_path / "output.md"
+        result = create_markdown_file(output, tmp_path / "missing.txt", sample_video_info)
+        assert result is False
+
+    def test_custom_front_matter(self, tmp_path, sample_video_info):
+        transcript = tmp_path / "transcript.txt"
+        transcript.write_text("Content")
+        output = tmp_path / "output.md"
+
+        create_markdown_file(
+            output,
+            transcript,
+            sample_video_info,
+            front_matter={"custom_key": "custom_value"},
+        )
+        content = output.read_text()
+        assert "custom_key: custom_value" in content
+
+
+# ============================================================================
+# create_analysis_markdown_file
+# ============================================================================
+
+
+class TestCreateAnalysisMarkdownFile:
+    @pytest.fixture
+    def analysis_results(self):
+        return {
+            "analysis_type": "executive_summary",
+            "analysis_name": "Executive Summary",
+            "analysis_text": "# Summary\n\nThis is the analysis.",
+            "provider": "groq",
+            "model": "test-model",
+            "tokens_input": 1000,
+            "tokens_output": 500,
+            "tokens_total": 1500,
+            "estimated_cost": 0.001,
+            "duration": 2.5,
+            "truncated": False,
+            "contextual_tags": ["python", "software"],
+        }
+
+    def test_creates_analysis_file(self, tmp_path, sample_video_info, analysis_results):
+        source = tmp_path / "2024-01-01_test.md"
+        source.touch()
+
+        result = create_analysis_markdown_file(
+            analysis_results,
+            source,
+            sample_video_info,
+            tmp_path,
+        )
+        assert result is not None
+        assert result.exists()
+
+        content = result.read_text()
+        assert "analysis_type: executive_summary" in content
+        assert "# Summary" in content
+        assert "python" in content
+
+    def test_filename_includes_analysis_type(self, tmp_path, sample_video_info, analysis_results):
+        source = tmp_path / "transcript.md"
+        source.touch()
+
+        result = create_analysis_markdown_file(
+            analysis_results,
+            source,
+            sample_video_info,
+            tmp_path,
+        )
+        assert "analysis_executive_summary" in result.name
+
+    def test_contextual_tags_merged(self, tmp_path, sample_video_info, analysis_results):
+        source = tmp_path / "test.md"
+        source.touch()
+
+        result = create_analysis_markdown_file(
+            analysis_results,
+            source,
+            sample_video_info,
+            tmp_path,
+        )
+        content = result.read_text()
+        # Should have both static and contextual tags
+        assert "analysis" in content
+        assert "python" in content
+        assert "software" in content
+
+    def test_missing_contextual_tags(self, tmp_path, sample_video_info, analysis_results):
+        analysis_results.pop("contextual_tags")
+        source = tmp_path / "test.md"
+        source.touch()
+
+        result = create_analysis_markdown_file(
+            analysis_results,
+            source,
+            sample_video_info,
+            tmp_path,
+        )
+        assert result is not None

--- a/tests/test_model_selector.py
+++ b/tests/test_model_selector.py
@@ -1,0 +1,294 @@
+"""Tests for pidcast.model_selector module."""
+
+from unittest.mock import patch
+
+import pytest
+
+from pidcast.exceptions import AnalysisError
+from pidcast.model_selector import (
+    ModelSelector,
+    is_rate_limit_error,
+    is_retryable_error,
+    load_models_config,
+    with_retry,
+)
+
+# ============================================================================
+# ModelConfig
+# ============================================================================
+
+
+class TestModelConfig:
+    def test_estimate_cost_basic(self, sample_model_config):
+        # 1M input tokens at $0.15, 1M output tokens at $0.60
+        cost = sample_model_config.estimate_cost(1_000_000, 1_000_000)
+        assert cost == pytest.approx(0.75)
+
+    def test_estimate_cost_zero_tokens(self, sample_model_config):
+        assert sample_model_config.estimate_cost(0, 0) == 0.0
+
+    def test_estimate_cost_small(self, sample_model_config):
+        # 1000 input, 500 output
+        cost = sample_model_config.estimate_cost(1000, 500)
+        expected = (1000 / 1_000_000) * 0.15 + (500 / 1_000_000) * 0.60
+        assert cost == pytest.approx(expected)
+
+
+# ============================================================================
+# ModelsConfig
+# ============================================================================
+
+
+class TestModelsConfig:
+    def test_get_model_exists(self, sample_models_config):
+        model = sample_models_config.get_model("large-model")
+        assert model is not None
+        assert model.name == "large-model"
+
+    def test_get_model_missing(self, sample_models_config):
+        assert sample_models_config.get_model("nonexistent") is None
+
+    def test_get_default(self, sample_models_config):
+        default = sample_models_config.get_default()
+        assert default is not None
+        assert default.name == "large-model"
+
+
+# ============================================================================
+# load_models_config
+# ============================================================================
+
+
+class TestLoadModelsConfig:
+    def test_load_valid_config(self, tmp_path):
+        config_file = tmp_path / "models.yaml"
+        config_file.write_text("""
+default_model: model-a
+fallback_chain:
+  - model-a
+models:
+  model-a:
+    display_name: Model A
+    provider: groq
+    context_window: 32768
+    pricing:
+      input: 0.1
+      output: 0.2
+    limits:
+      rpm: 30
+      rpd: 1000
+      tpm: 10000
+      tpd: 100000
+""")
+        config = load_models_config(config_file)
+        assert config.default_model == "model-a"
+        assert "model-a" in config.models
+        assert config.models["model-a"].display_name == "Model A"
+
+    def test_missing_file(self, tmp_path):
+        with pytest.raises(AnalysisError, match="not found"):
+            load_models_config(tmp_path / "missing.yaml")
+
+    def test_empty_file(self, tmp_path):
+        config_file = tmp_path / "models.yaml"
+        config_file.write_text("")
+        with pytest.raises(AnalysisError, match="empty"):
+            load_models_config(config_file)
+
+    def test_invalid_yaml(self, tmp_path):
+        config_file = tmp_path / "models.yaml"
+        config_file.write_text("{{invalid: yaml: [")
+        with pytest.raises(AnalysisError, match="Invalid YAML"):
+            load_models_config(config_file)
+
+    def test_unknown_default_model(self, tmp_path):
+        config_file = tmp_path / "models.yaml"
+        config_file.write_text("""
+default_model: nonexistent
+models:
+  model-a:
+    display_name: A
+""")
+        with pytest.raises(AnalysisError, match="not found in models"):
+            load_models_config(config_file)
+
+    def test_unknown_model_in_fallback_chain(self, tmp_path):
+        config_file = tmp_path / "models.yaml"
+        config_file.write_text("""
+default_model: model-a
+fallback_chain:
+  - model-a
+  - ghost-model
+models:
+  model-a:
+    display_name: A
+""")
+        with pytest.raises(AnalysisError, match="Unknown models in fallback_chain"):
+            load_models_config(config_file)
+
+
+# ============================================================================
+# is_retryable_error / is_rate_limit_error
+# ============================================================================
+
+
+class TestErrorClassification:
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "rate limit exceeded",
+            "Too Many Requests",
+            "Error 429",
+            "connection reset",
+            "timeout occurred",
+            "503 Service Unavailable",
+            "bad gateway",
+            "server is overloaded",
+        ],
+    )
+    def test_retryable_errors(self, msg):
+        assert is_retryable_error(Exception(msg)) is True
+
+    def test_non_retryable_error(self):
+        assert is_retryable_error(Exception("invalid api key")) is False
+
+    def test_rate_limit_specific(self):
+        assert is_rate_limit_error(Exception("rate limit exceeded")) is True
+        assert is_rate_limit_error(Exception("rate_limit_exceeded")) is True
+        assert is_rate_limit_error(Exception("429 too many")) is True
+        assert is_rate_limit_error(Exception("timeout")) is False
+
+
+# ============================================================================
+# with_retry
+# ============================================================================
+
+
+class TestWithRetry:
+    def test_succeeds_first_try(self):
+        @with_retry(max_retries=2, base_delay=0.01)
+        def always_works():
+            return "ok"
+
+        assert always_works() == "ok"
+
+    @patch("pidcast.model_selector.time.sleep")
+    def test_retries_on_retryable_error(self, mock_sleep):
+        call_count = 0
+
+        @with_retry(max_retries=2, base_delay=0.01)
+        def fails_then_succeeds():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise Exception("rate limit exceeded")
+            return "recovered"
+
+        assert fails_then_succeeds() == "recovered"
+        assert call_count == 2
+        assert mock_sleep.called
+
+    def test_raises_non_retryable_immediately(self):
+        call_count = 0
+
+        @with_retry(max_retries=3, base_delay=0.01)
+        def bad_key():
+            nonlocal call_count
+            call_count += 1
+            raise Exception("invalid api key")
+
+        with pytest.raises(Exception, match="invalid api key"):
+            bad_key()
+        assert call_count == 1
+
+    @patch("pidcast.model_selector.time.sleep")
+    def test_exhausts_retries(self, mock_sleep):
+        @with_retry(max_retries=2, base_delay=0.01)
+        def always_fails():
+            raise Exception("rate limit exceeded")
+
+        with pytest.raises(Exception, match="rate limit"):
+            always_fails()
+        assert mock_sleep.call_count == 2
+
+
+# ============================================================================
+# ModelSelector
+# ============================================================================
+
+
+class TestModelSelector:
+    def test_get_default_model(self, sample_models_config):
+        selector = ModelSelector(sample_models_config)
+        assert selector.get_default_model() == "large-model"
+
+    def test_get_display_name(self, sample_models_config):
+        selector = ModelSelector(sample_models_config)
+        assert selector.get_display_name("large-model") == "Large Model"
+        assert selector.get_display_name("unknown") == "unknown"
+
+    def test_tokens_within_context(self, sample_models_config):
+        selector = ModelSelector(sample_models_config)
+        # large-model: 131072 * 0.9 = 117964
+        assert selector.tokens_within_context("large-model", 100000) is True
+        assert selector.tokens_within_context("large-model", 120000) is False
+
+    def test_tokens_within_context_unknown_model(self, sample_models_config):
+        selector = ModelSelector(sample_models_config)
+        assert selector.tokens_within_context("unknown", 999999) is True
+
+    def test_get_max_context_tokens(self, sample_models_config):
+        selector = ModelSelector(sample_models_config)
+        assert selector.get_max_context_tokens("large-model") == int(131072 * 0.9)
+        assert selector.get_max_context_tokens("unknown") == 100000
+
+    def test_get_effective_token_limit(self, sample_models_config):
+        selector = ModelSelector(sample_models_config)
+        # large-model: min(131072*0.9, 8000) = 8000
+        assert selector.get_effective_token_limit("large-model") == 8000
+
+    def test_needs_chunking_fits(self, sample_models_config):
+        selector = ModelSelector(sample_models_config)
+        assert selector.needs_chunking(100000) is False  # fits in large-model
+
+    def test_needs_chunking_too_large(self, sample_models_config):
+        selector = ModelSelector(sample_models_config)
+        assert selector.needs_chunking(200000) is True  # exceeds all models
+
+    def test_select_model_preferred_fits(self, sample_models_config):
+        selector = ModelSelector(sample_models_config)
+        model, is_fallback = selector.select_model_for_tokens(1000, "large-model")
+        assert model == "large-model"
+        assert is_fallback is False
+
+    def test_select_model_falls_back(self, sample_models_config):
+        selector = ModelSelector(sample_models_config)
+        # Exceeds large-model context (131072*0.9) but not small-model? No, small is 32768.
+        # Both have 131072 and 32768. 120000 > 32768*0.9=29491 but < 131072*0.9=117964
+        model, is_fallback = selector.select_model_for_tokens(100000)
+        assert model == "large-model"
+        assert is_fallback is False
+
+    def test_select_model_none_when_too_large(self, sample_models_config):
+        selector = ModelSelector(sample_models_config)
+        model, is_fallback = selector.select_model_for_tokens(500000)
+        assert model is None
+        assert is_fallback is False
+
+    def test_handle_rate_limit(self, sample_models_config):
+        selector = ModelSelector(sample_models_config)
+        next_model = selector.handle_rate_limit("large-model")
+        assert next_model == "small-model"
+        assert "large-model" in selector.get_tried_models()
+
+    def test_handle_rate_limit_exhausted(self, sample_models_config):
+        selector = ModelSelector(sample_models_config)
+        selector.handle_rate_limit("large-model")
+        result = selector.handle_rate_limit("small-model")
+        assert result is None
+
+    def test_reset(self, sample_models_config):
+        selector = ModelSelector(sample_models_config)
+        selector.mark_tried("large-model")
+        selector.reset()
+        assert len(selector.get_tried_models()) == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,273 @@
+"""Tests for pidcast.utils module."""
+
+from unittest.mock import patch
+
+import pytest
+
+from pidcast.utils import (
+    create_smart_filename,
+    extract_youtube_video_id,
+    format_duration,
+    fuzzy_match_key,
+    get_unique_filename,
+    load_json_file,
+    sanitize_filename,
+    save_json_file,
+    suggest_closest_match,
+    validate_input_source,
+)
+
+# ============================================================================
+# sanitize_filename
+# ============================================================================
+
+
+class TestSanitizeFilename:
+    def test_removes_special_chars(self):
+        assert sanitize_filename("hello!@#world") == "helloworld"
+
+    def test_preserves_hyphens(self):
+        assert sanitize_filename("hello-world") == "hello-world"
+
+    def test_preserves_spaces(self):
+        assert sanitize_filename("hello world") == "hello world"
+
+    def test_empty_string(self):
+        assert sanitize_filename("") == ""
+
+    def test_strips_whitespace(self):
+        assert sanitize_filename("  hello  ") == "hello"
+
+
+# ============================================================================
+# create_smart_filename
+# ============================================================================
+
+
+class TestCreateSmartFilename:
+    @patch("pidcast.utils.datetime")
+    def test_includes_date_prefix(self, mock_dt):
+        mock_dt.datetime.now.return_value.strftime.return_value = "2024-01-15"
+        result = create_smart_filename("Great Talk About Python", include_date=True)
+        assert result.startswith("2024-01-15_")
+
+    def test_no_date_prefix(self):
+        result = create_smart_filename("Great Talk About Python", include_date=False)
+        assert not result[0].isdigit() or "_" not in result[:11]
+
+    def test_strips_episode_prefix(self):
+        result = create_smart_filename("Episode 42: The Answer", include_date=False)
+        assert "Episode" not in result
+        assert "42" not in result.split("_")[0]
+
+    def test_prioritizes_important_words(self):
+        result = create_smart_filename("The Quick Brown Fox", include_date=False, max_length=30)
+        # "Quick", "Brown", "Fox" are important (capitalized)
+        assert "Quick" in result or "Brown" in result
+
+    def test_respects_max_length(self):
+        long_title = "A " * 100 + "Very Important Word"
+        result = create_smart_filename(long_title, include_date=False, max_length=30)
+        # Without date prefix, should be within max_length (roughly)
+        assert len(result) <= 60  # some tolerance for word boundaries
+
+    def test_filler_words_stripped(self):
+        result = create_smart_filename("EP.5 - Interview", include_date=False)
+        assert "EP" not in result
+
+
+# ============================================================================
+# get_unique_filename
+# ============================================================================
+
+
+class TestGetUniqueFilename:
+    def test_no_collision(self, tmp_path):
+        result = get_unique_filename(tmp_path, "test", ".md")
+        assert result == tmp_path / "test.md"
+
+    def test_with_collision(self, tmp_path):
+        (tmp_path / "test.md").touch()
+        result = get_unique_filename(tmp_path, "test", ".md")
+        assert result == tmp_path / "test_v2.md"
+
+    def test_multiple_collisions(self, tmp_path):
+        (tmp_path / "test.md").touch()
+        (tmp_path / "test_v2.md").touch()
+        result = get_unique_filename(tmp_path, "test", ".md")
+        assert result == tmp_path / "test_v3.md"
+
+
+# ============================================================================
+# format_duration
+# ============================================================================
+
+
+class TestFormatDuration:
+    def test_seconds_only(self):
+        assert format_duration(45.23) == "45.23 seconds"
+
+    def test_exactly_60(self):
+        assert format_duration(60) == "1m 0s"
+
+    def test_minutes_and_seconds(self):
+        assert format_duration(90) == "1m 30s"
+
+    def test_hours(self):
+        assert format_duration(3661) == "61m 1s"
+
+    def test_zero(self):
+        assert format_duration(0) == "0.00 seconds"
+
+
+# ============================================================================
+# extract_youtube_video_id
+# ============================================================================
+
+
+class TestExtractYoutubeVideoId:
+    def test_standard_watch_url(self):
+        assert (
+            extract_youtube_video_id("https://www.youtube.com/watch?v=dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+        )
+
+    def test_short_url(self):
+        assert extract_youtube_video_id("https://youtu.be/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_with_tracking_params(self):
+        assert extract_youtube_video_id("https://youtu.be/dQw4w9WgXcQ?si=abc123") == "dQw4w9WgXcQ"
+
+    def test_with_feature_param(self):
+        assert (
+            extract_youtube_video_id("https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=shared")
+            == "dQw4w9WgXcQ"
+        )
+
+    def test_live_url(self):
+        assert extract_youtube_video_id("https://www.youtube.com/live/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_embed_url(self):
+        assert (
+            extract_youtube_video_id("https://www.youtube.com/embed/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+        )
+
+    def test_old_v_format(self):
+        assert extract_youtube_video_id("https://www.youtube.com/v/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_mobile_url(self):
+        assert (
+            extract_youtube_video_id("https://m.youtube.com/watch?v=dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+        )
+
+    def test_invalid_url(self):
+        assert extract_youtube_video_id("https://example.com/video") is None
+
+    def test_malformed_url(self):
+        assert extract_youtube_video_id("not a url at all") is None
+
+    def test_invalid_video_id_length(self):
+        assert extract_youtube_video_id("https://www.youtube.com/watch?v=short") is None
+
+
+# ============================================================================
+# validate_input_source
+# ============================================================================
+
+
+class TestValidateInputSource:
+    def test_youtube_url(self):
+        source, is_local = validate_input_source("https://www.youtube.com/watch?v=abc")
+        assert is_local is False
+
+    def test_local_audio_file(self, tmp_path):
+        audio = tmp_path / "test.mp3"
+        audio.touch()
+        source, is_local = validate_input_source(str(audio))
+        assert is_local is True
+
+    def test_unsupported_format(self, tmp_path):
+        video = tmp_path / "test.avi"
+        video.touch()
+        with pytest.raises(ValueError, match="Unsupported audio format"):
+            validate_input_source(str(video))
+
+    def test_invalid_input(self):
+        with pytest.raises(ValueError, match="Invalid input"):
+            validate_input_source("random string that is not a file or url")
+
+
+# ============================================================================
+# fuzzy_match_key
+# ============================================================================
+
+
+class TestFuzzyMatchKey:
+    def test_exact_match_case_insensitive(self):
+        assert fuzzy_match_key("Hello", ["hello", "world"]) == "hello"
+
+    def test_starts_with(self):
+        assert fuzzy_match_key("exec", ["executive_summary", "deep_dive"]) == "executive_summary"
+
+    def test_contains(self):
+        assert fuzzy_match_key("summary", ["executive_summary", "deep_dive"]) == "executive_summary"
+
+    def test_no_match(self):
+        assert fuzzy_match_key("xyz", ["hello", "world"]) is None
+
+    def test_multiple_starts_with_returns_shortest(self):
+        keys = ["deep_dive", "deep_analysis"]
+        result = fuzzy_match_key("deep", keys)
+        assert result == "deep_dive"  # shortest
+
+    def test_normalized_matching(self):
+        result = fuzzy_match_key("gptoss120b", ["openai/gpt-oss-120b"], normalize=True)
+        assert result == "openai/gpt-oss-120b"
+
+
+# ============================================================================
+# suggest_closest_match
+# ============================================================================
+
+
+class TestSuggestClosestMatch:
+    def test_close_match(self):
+        result = suggest_closest_match("exectuive_summary", ["executive_summary", "deep_dive"])
+        assert result == "executive_summary"
+
+    def test_no_close_match(self):
+        result = suggest_closest_match("zzzzzzz", ["hello", "world"])
+        assert result is None
+
+
+# ============================================================================
+# load_json_file / save_json_file
+# ============================================================================
+
+
+class TestJsonFileIO:
+    def test_load_existing_file(self, tmp_path):
+        f = tmp_path / "data.json"
+        f.write_text('{"key": "value"}')
+        result = load_json_file(f)
+        assert result == {"key": "value"}
+
+    def test_load_missing_file(self, tmp_path):
+        result = load_json_file(tmp_path / "missing.json", default=[])
+        assert result == []
+
+    def test_load_corrupt_json(self, tmp_path):
+        f = tmp_path / "bad.json"
+        f.write_text("{invalid json")
+        result = load_json_file(f, default={"fallback": True})
+        assert result == {"fallback": True}
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        f = tmp_path / "out.json"
+        data = {"items": [1, 2, 3], "nested": {"a": True}}
+        assert save_json_file(f, data) is True
+        assert load_json_file(f) == data
+
+    def test_save_creates_parent_dirs(self, tmp_path):
+        f = tmp_path / "sub" / "dir" / "data.json"
+        assert save_json_file(f, {"ok": True}) is True
+        assert f.exists()


### PR DESCRIPTION
## Summary
- Add 126 new tests across 4 modules: `chunking`, `model_selector`, `utils`, `markdown`
- Add `conftest.py` with shared fixtures (`sample_video_info`, `sample_model_config`, `sample_models_config`)
- Total test count goes from 64 to 190

## Why
Only 5 of ~24 modules had test coverage. The core pipeline modules (chunking, model selection, utilities, markdown generation) were entirely untested despite being mostly pure logic.

## Notes
- Focused on pure-logic functions first to maximize value with minimal mocking
- `with_retry` decorator tests mock `time.sleep` to avoid actual delays
- All tests pass lint (`ruff check`) and formatting (`ruff format`)