### PR TITLE
fix: transcode non-WAV audio and fix exception scoping in --diarize-existing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidcast"
-version = "0.8.1"
+version = "0.8.2"
 description = "YouTube transcription tool with Whisper and LLM analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pidcast/workflow.py
+++ b/src/pidcast/workflow.py
@@ -537,18 +537,51 @@ def run_diarize_existing_mode(
 
         # Validate HuggingFace token
         if not HUGGINGFACE_TOKEN:
-            from .exceptions import DiarizationError
-
             raise DiarizationError(
                 "HUGGINGFACE_TOKEN environment variable not set. Required for speaker diarization."
             )
+
+        # pyannote's soundfile backend only reads WAV/FLAC/OGG; transcode anything else.
+        diarize_input = audio_file
+        tmp_wav: Path | None = None
+        if audio_file.suffix.lower() != ".wav":
+            import subprocess
+            import tempfile
+
+            from .transcription import build_ffmpeg_audio_conversion_command
+
+            tmp_wav = Path(tempfile.mkstemp(prefix="pidcast_diarize_", suffix=".wav")[1])
+            logger.info(f"Converting {audio_file.name} to 16kHz mono WAV for diarization...")
+            command = build_ffmpeg_audio_conversion_command(
+                str(audio_file),
+                str(tmp_wav),
+                overwrite=True,
+            )
+            try:
+                if verbose:
+                    subprocess.run(command, check=True)
+                else:
+                    subprocess.run(
+                        command,
+                        check=True,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.PIPE,
+                    )
+            except subprocess.CalledProcessError as e:
+                tmp_wav.unlink(missing_ok=True)
+                raise DiarizationError(f"Failed to convert audio to WAV: {e}") from e
+            diarize_input = tmp_wav
 
         # Run diarization
         logger.info("Running speaker diarization...")
         import time
 
         start_time = time.time()
-        diarization_segments = run_diarization(str(audio_file), HUGGINGFACE_TOKEN, verbose)
+        try:
+            diarization_segments = run_diarization(str(diarize_input), HUGGINGFACE_TOKEN, verbose)
+        finally:
+            if tmp_wav is not None:
+                tmp_wav.unlink(missing_ok=True)
         diarization_duration = time.time() - start_time
 
         # Read whisper JSON and merge


### PR DESCRIPTION
## Summary

- **User impact:** `pidcast --diarize-existing <transcript.md> --audio file.m4a` now works on any ffmpeg-supported format instead of failing with `LibsndfileError: Format not recognised`. Previously the only working input was a WAV file.
- **Bug fix:** when the diarization error path *did* trigger, it was masked by an `UnboundLocalError` from a shadowed exception import inside `run_diarize_existing_mode`, hiding the real failure from users.

## Changes

- `workflow.py`: transcode non-`.wav` inputs to a temp 16kHz mono WAV via the existing ffmpeg helper before handing to pyannote (matches the behavior of `scripts/diarize-existing.sh`). Clean up the temp file in a `finally`.
- `workflow.py`: drop the redundant local `from .exceptions import DiarizationError` inside `run_diarize_existing_mode` — it rebound the name as function-local, so when the HUGGINGFACE_TOKEN branch did not run, the outer `except DiarizationError` saw an unbound local.

## Test plan

- [ ] Run `pidcast --diarize-existing <existing transcript.md> --audio <m4a file>` end-to-end; confirm successful diarization output.
- [ ] Run the same with a `.wav` input; confirm the original fast-path still works (no temp file created when not needed).
- [ ] Force a diarization failure (e.g. invalid HF token) and confirm the original `DiarizationError` surfaces clearly, not an `UnboundLocalError`.