### PR TITLE
chore: install mermaid pre-commit hook and ignore stray transcripts

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -82,3 +82,31 @@ if [ -n "$PLANTUML_STAGED_MD" ]; then
     fi
 fi
 # <<< tribe-coding/plantuml <<<
+
+# >>> tribe-coding/mermaid >>>
+# Mermaid syntax validation — installed by mermaid Claude Code plugin.
+# Do not edit between markers; managed automatically by setup-project.sh.
+MERMAID_STAGED_MD=$(git diff --cached --name-only --diff-filter=ACM -- '*.md')
+
+if [ -n "$MERMAID_STAGED_MD" ]; then
+    MERMAID_VALIDATOR=""
+    for candidate in \
+        "$HOME/.claude/plugins/cache/tribe-coding/mermaid/scripts/validate-mermaid.py" \
+        "$HOME/.claude/plugins/marketplaces/tribe-coding/plugins/mermaid/scripts/validate-mermaid.py" \
+        "$(git rev-parse --show-toplevel 2>/dev/null)/scripts/validate-mermaid.py"; do
+        if [ -f "$candidate" ]; then
+            MERMAID_VALIDATOR="$candidate"
+            break
+        fi
+    done
+
+    if [ -n "$MERMAID_VALIDATOR" ]; then
+        if ! python3 "$MERMAID_VALIDATOR" $MERMAID_STAGED_MD; then
+            echo ""
+            echo "Commit blocked: Mermaid diagrams have syntax errors."
+            echo "  Fix the errors reported above, or set MERMAID_KROKI_URL if Kroki is unreachable."
+            exit 1
+        fi
+    fi
+fi
+# <<< tribe-coding/mermaid <<<

--- a/.gitignore
+++ b/.gitignore
@@ -207,6 +207,11 @@ pyrightconfig.json
 
 # Claude code
 .claude/settings.local.json
+.claude/skills/
+
+# Stray transcripts dropped in repo root (canonical location is data/transcripts/)
+/20[0-9][0-9]-[01][0-9]-[0-3][0-9]_*.md
+/20[0-9][0-9]-[01][0-9]-[0-3][0-9]_*.whisper.json
 
 # Worktrees
 .worktrees/


### PR DESCRIPTION
## Summary

- **User impact:** committing a markdown file with a broken Mermaid diagram is now blocked at the pre-commit stage with a clear error message, rather than only being caught later when GitHub fails to render the diagram.
- Repo housekeeping: stray transcript files dropped in the repo root are now gitignored so they no longer pollute `git status`, and local Claude Code skill scaffolds under `.claude/skills/` are ignored.

## Changes

- `.githooks/pre-commit`: add the Mermaid validation block from the tribe-coding `mermaid` plugin (POSTs each \`\`\`mermaid block in staged `.md` files to Kroki). Fail-soft if Kroki is unreachable; configurable via `MERMAID_KROKI_URL`.
- `.gitignore`:
  - Ignore `.claude/skills/` (local plugin scaffolds, not versioned).
  - Ignore root-level transcript files matching `YYYY-MM-DD_*.md` and `*.whisper.json`. Canonical transcript location is `data/transcripts/` (already ignored via the `data/` rule).

## Test plan

- [ ] Stage a `.md` file with a deliberately broken \`\`\`mermaid block; confirm commit is blocked with a syntax error message.
- [ ] Stage a `.md` file with a valid Mermaid diagram; confirm commit passes.
- [ ] Create a stray `2026-05-11_test.md` in the repo root; confirm it does not appear in `git status`.