### PR TITLE
docs: refresh README, CLAUDE.md, and add architecture + ADRs

### DIFF
--- a/.claude-plugin/kb-grooming.json
+++ b/.claude-plugin/kb-grooming.json
@@ -1,0 +1,42 @@
+{
+  "model": "sonnet",
+  "scope": {
+    "include": ["README.md", "CLAUDE.md", "docs/", "*.md"],
+    "exclude": [
+      "node_modules/",
+      ".git/",
+      "vendor/",
+      "dist/",
+      "build/",
+      ".venv/",
+      "venv/",
+      ".pytest_cache/",
+      ".ruff_cache/",
+      ".mypy_cache/",
+      "data/",
+      ".claude/skills/",
+      "docs/plans/",
+      "docs/ideation/",
+      "docs/ultrathink/"
+    ]
+  },
+  "checks": {
+    "brokenLinks": true,
+    "orphanDocs": true,
+    "duplicateContent": true,
+    "claudemdOverflow": true,
+    "mandatoryDocs": true,
+    "readmeCompliance": true,
+    "terminologyConsistency": true,
+    "adrCompleteness": true,
+    "contentActuality": true
+  },
+  "output": {
+    "githubIssues": false,
+    "reportFile": true
+  },
+  "github": {
+    "labels": ["documentation", "kb-grooming"],
+    "assignee": ""
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,72 +1,80 @@
 # Project: pidcast
 
-YouTube transcription and analysis tool using Whisper and Groq. Generates Obsidian-ready Markdown with smart metadata.
+Single-shot CLI that turns a URL or audio file into an Obsidian-ready Markdown transcript with optional LLM analysis. See [README.md](README.md) for user-facing overview and [docs/architecture.md](docs/architecture.md) for system structure.
 
-## Tech Stack
+## Tech stack
 
-- **Runtime:** Python (managed via `uv`)
-- **Audio/Video:** `yt-dlp`, `ffmpeg`, `ffprobe`
-- **Transcription:** `whisper.cpp` (via `pidcast/transcription.py`)
-- **LLM Analysis:** Groq API with JSON mode for structured output
+- **Runtime:** Python ≥ 3.10, managed via `uv`
+- **Audio:** `yt-dlp`, `ffmpeg`, `ffprobe`
+- **Transcription providers:** `whisper.cpp` (local, default) and ElevenLabs Scribe v2 (cloud)
+- **Diarization:** `pyannote.audio` (whisper path, needs HF token) or built-in (ElevenLabs path)
+- **LLM providers:** Groq (default, JSON mode) or Claude via the Claude Code CLI
 
-## Core Commands
+## Core commands
 
-**Transcription:**
+Run with `uv run pidcast <input>`. Useful entry points:
 
-- **Run tool:** `uv run pidcast "URL_OR_PATH"`
-- **Save to Obsidian:** `uv run pidcast "URL" --save-to-obsidian` (saves analysis only)
-- **Analyze existing:** `uv run pidcast --analyze-existing transcript.md`
-- **Test segment:** `uv run pidcast "URL" --test-segment --diarize` (test settings on first 2 min)
-- **Test from offset:** `uv run pidcast "URL" --test-segment 3 --start-at 10` (3 min from 10:00)
-- **Re-diarize:** `uv run pidcast --diarize-existing transcript.md` (retry diarization without re-transcribing)
+| Command | Purpose |
+|---------|---------|
+| `pidcast <URL_OR_PATH>` | Transcribe + analyze |
+| `pidcast setup` | Interactive setup wizard (env, deps, API keys) |
+| `pidcast doctor` | Diagnose tooling/env configuration |
+| `pidcast --analyze-existing transcript.md` | Re-analyze without re-transcribing |
+| `pidcast --diarize-existing transcript.md [--audio file]` | Retry diarization only |
+| `pidcast --test-segment [MIN] [--start-at MIN]` | Dry-run transcription on a slice |
+| `pidcast --transcription-provider {whisper,elevenlabs}` | Pick transcription backend |
+| `pidcast --provider {groq,claude}` | Pick LLM analysis backend |
+| `pidcast lib {add,list,show,remove,sync,process,digest}` | Manage podcast subscriptions |
+| `pidcast -L \| -M \| -W \| -P` | List analysis types / LLM models / Whisper models / presets |
 
-**Library Management:**
+Environment: copy `.env.example` → `.env`. See [docs/development-guide.md](docs/development-guide.md) for the full var list.
 
-- **Add show:** `uv run pidcast lib add "FEED_URL"`
-- **List shows:** `uv run pidcast lib list`
-- **Show details:** `uv run pidcast lib show ID`
-- **Remove show:** `uv run pidcast lib remove ID`
-- **Sync library:** `uv run pidcast lib sync`
-- **Generate digest:** `uv run pidcast lib digest`
+## Build, test, lint
 
-**Environment:** Requires `.env` (see `.env.example`)
+```bash
+uv sync --group dev          # install runtime + dev deps
+uv run pytest                # run tests
+uv run ruff check src/       # lint
+uv run ruff format src/      # format
+pre-commit install           # enable pre-commit hooks (ruff, mermaid)
+```
 
-## Module Architecture
+## Module map
 
-**Core Modules:**
+Source lives under `src/pidcast/`. Hot-path modules (read these first when debugging a workflow):
 
-- `cli.py` - Command-line interface, argument parsing, main transcription flow
-- `analysis.py` - LLM-based transcript analysis using Groq API with JSON mode
-- `transcription.py` - Whisper.cpp integration for audio-to-text transcription
-- `download.py` - YouTube video downloading via yt-dlp
-- `markdown.py` - Markdown file creation with YAML front matter
-- `chunking.py` - Semantic transcript chunking for long content
-- `model_selector.py` - LLM model selection and fallback logic
-- `config.py` - Configuration constants, dataclasses, environment variables
-- `utils.py` - Utility functions (filenames, logging, JSON I/O, duplicate detection)
-- `exceptions.py` - Custom exception classes
+- `cli.py` — argparse surface; dispatches to `workflow.py` and the `lib` subcommands
+- `workflow.py` — orchestration: download → transcribe → diarize → analyze → write
+- `transcription.py` + `providers/` — provider dispatch for whisper/ElevenLabs
+- `diarization.py` — pyannote integration; consumes whisper JSON or ElevenLabs speakers
+- `analysis.py` + `summarization.py` — Groq/Claude prompt execution, JSON validation
+- `chunking.py` — semantic chunking for transcripts > 120k chars
+- `markdown.py` — front matter assembly, smart filename construction
+- `library.py` + `sync.py` + `rss.py` + `apple_podcasts.py` + `discovery.py` — podcast library subsystem
+- `digest.py` + `history.py` — processing history + digest generation
+- `download.py` + `cookies.py` — yt-dlp wrapper, browser cookie extraction
+- `config.py` + `config_manager.py` + `model_selector.py` + `setup.py` — config, model fallback chain, setup wizard
+- `evals/` — provider comparison evals (`pidcast-eval` entry point)
+- `exceptions.py` + `utils.py` — shared error types, filename/duplicate helpers
 
-**Configuration:**
+## Engineering conventions
 
-- `config/prompts.yaml` - LLM analysis prompts with JSON response format
-- `config/models.yaml` - LLM model definitions and rate limits
-- `data/transcripts/transcription_stats.json` - Historical run statistics
+- **Workflow:** "plan then execute" — propose changes before editing.
+- **Audio pipeline:** standardize to 16kHz mono WAV before transcription regardless of source format.
+- **Chunking threshold:** transcripts > 120k chars use semantic chunking with synthesis.
+- **LLM responses:** every analysis prompt returns JSON with `analysis` and `contextual_tags` fields.
+- **Filenames:** smart-filtered with `YYYY-MM-DD_Title.md` date prefix.
+- **Transcripts location:** `data/transcripts/` is canonical — never drop stray transcripts in the repo root (ignored via `.gitignore`).
+- **Linting:** ruff is the single source of truth (config in `pyproject.toml` under `[tool.ruff]`).
 
-## Engineering Conventions
+## Data handling
 
-- **Workflow:** Always "Plan then execute." Propose changes before editing.
-- **File Naming:** Smart filtering applies date prefixes (`YYYY-MM-DD_Title.md`).
-- **Audio Pipeline:** Standardize to 16kHz mono WAV before transcription.
-- **Constraints:** Transcripts >120k chars use semantic chunking with synthesis.
-- **LLM Responses:** All analysis prompts now return JSON with `analysis` and `contextual_tags` fields.
-- Use ruff for linting and syntax
+`data/transcripts/` contains large text files (some > 200 KB). **Do NOT read these into context** unless the user explicitly approves a specific file. For test fixtures, ask the user to point at one or create a dedicated minimal fixture under `tests/`.
 
-## Data Files & Testing
+## Further reading
 
-**IMPORTANT:** DO NOT read transcript files in `/data/transcripts/` unless critically necessary and explicitly approved by the user. These files contain large amounts of text and will consume significant context. If you need sample transcripts for testing, request the user to specify which files to use or create a dedicated test fixtures file.
-
-## Progressive Disclosure
-
-- **API Details:** Refer to `analysis.py` for LLM API integration and JSON parsing.
-- **Prompting:** Templates defined in `config/prompts.yaml` with JSON structure.
-- **Duplicate Detection:** See `utils.py` for `find_existing_transcription()` logic.
+- [docs/architecture.md](docs/architecture.md) — components, data flow, diagrams
+- [docs/development-guide.md](docs/development-guide.md) — dev environment, testing, CI
+- [docs/adr/](docs/adr/) — Architecture Decision Records (provider abstractions)
+- `config/prompts.yaml` — analysis prompt templates
+- `config/models.yaml` — LLM model definitions and fallback chains

--- a/README.md
+++ b/README.md
@@ -1,324 +1,154 @@
-# Pidcast - Podcast & YouTube Transcription Tool
+# pidcast
 
-Transcription and LLM-powered analysis tool for podcasts, YouTube videos, and local audio files. Uses whisper.cpp for local transcription and Groq or Claude for structured analysis. Outputs Obsidian-ready Markdown with YAML front matter.
+> [!TIP]
+> ✨ ***A URL or audio file in, an Obsidian-ready Markdown transcript with smart LLM analysis out.***
 
-## Features
+pidcast is a single-shot CLI for podcast and YouTube transcription with optional LLM analysis. Built for engineers and knowledge-workers who want **searchable, source-attributed notes** out of long-form audio — without leaving the terminal. Whisper.cpp or ElevenLabs handles speech-to-text; Groq or Claude handles the analysis; output lands as Markdown with YAML front matter, ready for Obsidian.
 
-- **Multiple input sources** - YouTube videos, Apple Podcasts URLs, podcast RSS feeds, and local audio files
-- **Transcription providers** - whisper.cpp (local) or ElevenLabs Scribe v2 (cloud API)
-- **Speaker diarization** - optional speaker identification via pyannote.audio (whisper) or built-in (ElevenLabs)
-- **LLM analysis** with Groq AI (enabled by default)
-  - Automatic model fallback and retry logic
-  - Smart chunking for long transcripts with semantic boundaries
-  - JSON-validated structured output
-  - **Shareable brief** in every analysis - punchy headline + friend-ready quick take for sharing links
-- **Library management** - Manage podcast RSS feeds with persistent storage
-  - Add shows by name (searches Apple Podcasts DB + iTunes API) or by RSS URL
-  - Sync and process new episodes automatically
-  - Generate digests from processing history
-- **Provider comparison evals** - Run the same transcript through Groq and Claude, judge quality with Opus
-- **Markdown output** with YAML front matter and smart source-aware tags (YouTube, Apple Podcasts, local file) - override with `--tags`
-- **Smart filenames** with date prefixes
-- **Fast dependencies** managed with uv
+> [!NOTE]
+> [📦 Installation](#installation) · [🔧 Setup](#setup) · [⚡ Usage](#usage) · [🎙️ Library](#library) · [🗣️ Speaker diarization](#diarization) · [📊 Evals](#evals) · [📚 Documentation](#documentation)
 
-![Pidcast example run](assets/screenshots/pidcast-example.png)
+## 🎬 Demo <a name="demo"></a>
 
-## Quick start
-
-### Path A: Cloud transcription (fastest - 5 min setup)
-
-No local models needed. Uses [ElevenLabs Scribe v2](https://elevenlabs.io/) for transcription.
+![pidcast transcribing and analyzing a YouTube episode](assets/screenshots/pidcast-example.png)
 
 ```bash
-# 1. Install uv (Python package manager)
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# 2. Clone and install
-git clone https://github.com/kintecus/pidcast && cd pidcast && uv sync
-
-# 3. Run guided setup (will ask for your ElevenLabs API key)
-uv run pidcast setup
-
-# 4. Transcribe!
-uv run pidcast "https://youtube.com/watch?v=VIDEO_ID"
+$ uv run pidcast "https://youtube.com/watch?v=VIDEO_ID"
+[1/5] Downloading audio ............................. ok (3m 21s)
+[2/5] Normalizing to 16kHz mono WAV ................. ok
+[3/5] Transcribing (whisper.cpp, large-v3-turbo) .... ok (4m 02s)
+[4/5] Analyzing (groq, llama-3.3-70b-versatile) ..... ok
+[5/5] Writing Markdown .............................. ok
+→ 2026-05-11_Episode_Title.md  (12,847 words, 3 speakers)
 ```
 
-### Path B: Local transcription (private - no audio leaves your machine)
+## 📦 Installation <a name="installation"></a>
 
-Uses [whisper.cpp](https://github.com/ggerganov/whisper.cpp) locally. Requires ffmpeg and building whisper.cpp.
+**Requirements:** Python ≥ 3.10, `ffmpeg`, and (for local transcription) a built `whisper.cpp`.
 
 ```bash
-# 1. Install uv and ffmpeg
+# 1. Install uv if you don't have it
 curl -LsSf https://astral.sh/uv/install.sh | sh
-brew install ffmpeg  # macOS, or: apt install ffmpeg
 
-# 2. Clone and install
+# 2. Clone and sync
 git clone https://github.com/kintecus/pidcast && cd pidcast && uv sync
 
-# 3. Run guided setup (will walk you through whisper.cpp)
-uv run pidcast setup
-
-# 4. Transcribe!
-uv run pidcast "https://youtube.com/watch?v=VIDEO_ID"
+# 3. Optional: ffmpeg
+brew install ffmpeg              # macOS — or: apt install ffmpeg
 ```
 
-### Troubleshooting
+## 🔧 Setup <a name="setup"></a>
 
-Run `pidcast doctor` at any time to check your configuration:
+```bash
+uv run pidcast setup
+```
+
+The wizard configures:
+
+- **Transcription backend** — local `whisper.cpp` (private, free) or ElevenLabs Scribe v2 (cloud, faster)
+- **API keys** — Groq for analysis, optionally ElevenLabs for cloud transcription, optionally HuggingFace for diarization
+- **Output paths** — transcript directory and optional Obsidian vault
+
+At any time, check the live state of your tooling and env:
 
 ```bash
 uv run pidcast doctor
 ```
 
-### Optional configuration
+Configuration is read from `.env` (see `.env.example`). Full variable reference: [docs/development-guide.md](docs/development-guide.md#environment-variables).
 
-Set these in `.env` for additional features:
-
-- `GROQ_API_KEY` - AI-powered analysis of transcripts (free at <https://console.groq.com/>)
-- `OBSIDIAN_VAULT_PATH` - Save analysis to Obsidian vault (`-o` flag)
-- `HUGGINGFACE_TOKEN` - Speaker diarization with whisper (`--diarize` flag)
-
-## Usage examples
-
-### Single video/episode transcription
+## ⚡ Usage <a name="usage"></a>
 
 ```bash
-# Basic transcription with analysis (default)
-uv run pidcast "https://www.youtube.com/watch?v=VIDEO_ID"
+# YouTube, Apple Podcasts URL, or local audio file
+uv run pidcast "https://youtube.com/watch?v=VIDEO_ID"
+uv run pidcast "https://podcasts.apple.com/.../id123?i=456"
+uv run pidcast "/path/to/audio.mp3"
 
-# Transcription only (skip analysis)
-uv run pidcast "VIDEO_URL" --no-analyze
+# Pick a transcription provider
+uv run pidcast "URL" --transcription-provider elevenlabs
 
-# Different analysis type
-uv run pidcast "VIDEO_URL" -a key_points
+# Pick an LLM provider for analysis
+uv run pidcast "URL" --provider claude --claude-model opus
 
-# Analyze existing transcript without re-transcribing
-uv run pidcast --analyze-existing transcript.md
+# Pick an analysis type (or skip analysis entirely)
+uv run pidcast "URL" -a key_points
+uv run pidcast "URL" --no-analyze
 
-# Transcribe local audio file
-uv run pidcast "/path/to/audio/file.mp3"
-
-# Custom tags (overrides auto-inferred source tags)
+# Custom front matter tags (overrides auto-inferred source tags)
 uv run pidcast "/path/to/meeting.mp3" --tags meeting,standup,weekly
 
-# Specify transcription language
-uv run pidcast "VIDEO_URL" -l uk
+# Test settings on a 2-minute slice before committing to a long run
+uv run pidcast "URL" --test-segment
 
-# Transcribe with speaker diarization
-uv run pidcast "VIDEO_URL" --diarize
+# Reuse an existing transcript
+uv run pidcast --analyze-existing transcript.md          # re-analyze
+uv run pidcast --diarize-existing transcript.md          # retry diarization
 
-# Force re-transcription (skip duplicate detection)
-uv run pidcast "VIDEO_URL" -f
-
-# Verbose output
-uv run pidcast "VIDEO_URL" -v
-
-# Use PO Token for restricted YouTube videos
-uv run pidcast "VIDEO_URL" --po-token "client.type+TOKEN"
+# Discovery flags
+uv run pidcast -L     # list analysis types
+uv run pidcast -M     # list LLM models
+uv run pidcast -W     # list Whisper models
+uv run pidcast -P     # list presets
 ```
 
-### Choosing a transcription provider
+Available analysis types: `executive_summary` (default), `summary`, `key_points`, `action_items`, `comprehensive`. Every type ends with a **Shareable Brief** — a punchy headline (≤ 15 words) plus a 3–5 sentence quick-take suitable for sending to a friend.
 
-By default, transcription uses local whisper.cpp. Pass `--transcription-provider elevenlabs` to use the ElevenLabs Scribe v2 cloud API instead:
+Claude model aliases: `sonnet` (claude-sonnet-4-6, default), `opus` (claude-opus-4-6), `haiku` (claude-haiku-4-5).
 
-```bash
-# Local whisper.cpp (default)
-uv run pidcast "VIDEO_URL"
+## 🎙️ Library <a name="library"></a>
 
-# ElevenLabs cloud transcription (faster, requires ELEVENLABS_API_KEY)
-uv run pidcast "VIDEO_URL" --transcription-provider elevenlabs
-
-# ElevenLabs with built-in speaker diarization
-uv run pidcast "VIDEO_URL" --transcription-provider elevenlabs --diarize
-```
-
-ElevenLabs Scribe v2 includes built-in speaker diarization (no HuggingFace token needed). Transcription time estimates adapt per-provider based on historical run data.
-
-### Choosing an LLM provider
-
-By default, analysis uses Groq. Pass `--provider claude` to use your local Claude Code installation instead:
+Subscribe to podcast feeds and process new episodes in one command.
 
 ```bash
-# Analyze with Claude (requires Claude Code installed and authenticated)
-uv run pidcast "VIDEO_URL" --provider claude
-
-# Choose a specific Claude model (sonnet is default)
-uv run pidcast "VIDEO_URL" --provider claude --claude-model opus
-
-# Groq is the default (no flag needed)
-uv run pidcast "VIDEO_URL" --provider groq
-```
-
-Available Claude model aliases: `sonnet` (claude-sonnet-4-6), `opus` (claude-opus-4-6), `haiku` (claude-haiku-4-5).
-
-### Library management
-
-Manage a persistent library of podcast shows for batch processing:
-
-```bash
-# Add a podcast by name (searches Apple Podcasts DB and iTunes)
+# Add a show by name (searches Apple Podcasts + iTunes) or by RSS URL
 uv run pidcast lib add "Lex Fridman Podcast"
-
-# Add a podcast directly by RSS feed URL
 uv run pidcast lib add "https://feeds.example.com/podcast.xml"
 
-# Preview episodes before adding
-uv run pidcast lib add "https://feeds.example.com/podcast.xml" --preview
+# Inspect
+uv run pidcast lib list                    # all shows
+uv run pidcast lib show 1 --episodes 10    # recent episodes for show ID 1
 
-# List all shows in library
-uv run pidcast lib list
+# Process one episode
+uv run pidcast lib process "Lex Fridman" --latest
+uv run pidcast lib process "Lex Fridman" --match "episode title"
 
-# Show details for a specific podcast (with recent episodes)
-uv run pidcast lib show 1
-
-# Show more episodes
-uv run pidcast lib show 1 --episodes 10
-
-# Remove a show from library
-uv run pidcast lib remove 1
-
-# Sync library and process new episodes
+# Process all new episodes across the library
 uv run pidcast lib sync
 
-# Process a specific episode from a show
-uv run pidcast lib process "show name" --latest
-uv run pidcast lib process "show name" --match "episode title"
-
-# Generate digest from processing history
+# Roll up recent processing history into a digest
 uv run pidcast lib digest
 ```
 
-When adding by name, pidcast first checks the local Apple Podcasts SQLite database (macOS only), then falls back to the iTunes Search API. You select from a numbered list of matches.
+Library file: `~/.config/pidcast/library.yaml` (macOS/Linux) or `%APPDATA%\pidcast\library.yaml` (Windows). Human-readable, hand-editable.
 
-The library is stored at `~/.config/pidcast/library.yaml` (or `%APPDATA%\pidcast\library.yaml` on Windows) and is human-readable and editable.
+## 🗣️ Speaker diarization <a name="diarization"></a>
 
-## Speaker diarization
+Identify who said what. Two paths:
 
-Optional speaker identification (who said what) using [pyannote.audio](https://github.com/pyannote/pyannote-audio). Runs locally - the HuggingFace token is only needed to download the model on first use.
-
-### Setup
-
-1. **Install diarization extra**:
-
-   ```bash
-   uv pip install 'pidcast[diarize]'
-   ```
-
-2. **Get a HuggingFace token** - go to [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens), create a token with `read` scope, and add to `.env`:
-
-   ```bash
-   HUGGINGFACE_TOKEN=hf_your_token_here
-   ```
-
-3. **Accept pyannote model licenses** (one-time, both required):
-   - [pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1)
-   - [pyannote/segmentation-3.0](https://huggingface.co/pyannote/segmentation-3.0)
-
-4. **Run**:
-
-   ```bash
-   uv run pidcast "VIDEO_URL" --diarize
-   ```
-
-First run downloads the model (~1 GB), subsequent runs use cache. Output includes `**Speaker 1**` / `**Speaker 2**` labels and front matter fields `speaker_count` and `diarized: true`.
-
-## Analysis prompts and configuration
-
-### Prompt templates
-
-Prompts are configured in `config/prompts.yaml`. Each prompt template defines:
-
-- System and user prompts with variable substitution
-- Max output tokens
-- JSON response format for structured output with `analysis` and `contextual_tags`
-
-Available analysis types:
-
-- `executive_summary` (default) - Concise overview with key insights
-- `summary` - Comprehensive summary
-- `key_points` - Bulleted highlights
-- `action_items` - Actionable takeaways
-- `comprehensive` - Archival-quality detailed guide
-
-All analysis types include a **Shareable Brief** section at the end: a reformulated headline (≤15 words) plus a 3-5 sentence casual quick take suitable for sharing with friends.
-
-### Model configuration
-
-Models and fallback chains are defined in `config/models.yaml`:
-
-- Automatic fallback on rate limits or failures
-- Token-based model selection for long transcripts
-- Smart chunking for content exceeding context windows
-
-### Chunking strategy
-
-Long transcripts are automatically chunked with:
-
-- Semantic boundary detection (paragraph/sentence breaks)
-- Overlap between chunks for context preservation
-- Synthesis step to combine chunk analyses
-
-## Provider comparison evals
-
-Compare Groq and Claude summaries on the same transcript, judged by Claude Opus:
+- **whisper + pyannote** (`--diarize` with `--transcription-provider whisper`): runs locally, needs a HuggingFace token to download the model on first use. Install with `uv pip install 'pidcast[diarize]'`, set `HUGGINGFACE_TOKEN` in `.env`, and accept the license at [pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1) and [pyannote/segmentation-3.0](https://huggingface.co/pyannote/segmentation-3.0).
+- **ElevenLabs built-in** (`--diarize` with `--transcription-provider elevenlabs`): no extra setup, runs as part of the transcription API call.
 
 ```bash
-# Run comparison (requires a plain-text transcript file)
-pidcast-eval --compare groq,claude --transcript-file transcript.txt --title "Episode Title"
-
-# Use a different Claude model for analysis
-pidcast-eval --compare groq,claude --claude-model opus --transcript-file transcript.txt
-
-# Use a different judge model (default: opus)
-pidcast-eval --compare groq,claude --judge sonnet --transcript-file transcript.txt
-
-# Different analysis type
-pidcast-eval --compare groq,claude --analysis-type comprehensive --transcript-file transcript.txt
+uv run pidcast "URL" --diarize
 ```
 
-The judge scores each summary on accuracy, completeness, clarity, and conciseness (1-10 each) and returns a verdict with reasoning. Results are saved as markdown reports in `data/evals/comparisons/`.
+Output adds `**Speaker 1**` / `**Speaker 2**` labels inline and front matter fields `speaker_count` and `diarized: true`.
 
-For matrix evals across multiple prompts, models, and reference transcripts:
+## 📊 Evals <a name="evals"></a>
+
+Compare provider output quality on the same transcript, judged by Claude Opus:
 
 ```bash
-# Run all combinations
-pidcast-eval --run-matrix
-
-# Subset of models
-pidcast-eval --run-matrix --models "llama-3.3-70b-versatile,mixtral-8x7b-32768"
+uv run pidcast-eval --compare groq,claude --transcript-file transcript.txt --title "Episode"
+uv run pidcast-eval --run-matrix           # all prompt × model × reference combos
 ```
 
-## Development
+Reports land in `data/evals/comparisons/`. See [docs/development-guide.md](docs/development-guide.md#provider-comparison-evals) for the full eval matrix flags.
 
-### Code quality
+## 📚 Documentation <a name="documentation"></a>
 
-Pre-commit hooks run ruff linting and formatting automatically on each commit. To set up:
-
-```bash
-pre-commit install
-```
-
-Manual usage:
-
-```bash
-uv run ruff format src/
-uv run ruff check src/
-uv run ruff check --fix src/
-```
-
-### Adding dependencies
-
-```bash
-# Add runtime dependency
-uv add package-name
-
-# Add dev dependency
-uv add --dev package-name
-
-# Update all dependencies
-uv sync --upgrade
-```
-
-## License
-
-MIT
+- [Architecture](docs/architecture.md) — system structure, data flow, component boundaries
+- [Development guide](docs/development-guide.md) — env setup, testing, CI, conventions
+- [Architecture Decision Records](docs/adr/) — why-we-chose decisions
+- [CLAUDE.md](CLAUDE.md) — Claude Code agent instructions for this repo

--- a/docs/adr/0001-transcription-providers.md
+++ b/docs/adr/0001-transcription-providers.md
@@ -1,0 +1,39 @@
+# ADR 0001 — Two transcription providers behind one CLI flag
+
+**Status:** Accepted (2026-03-18, ElevenLabs landed in PR #10)
+
+## Context
+
+Local `whisper.cpp` was the only transcription path until early 2026. It is private and free, but it has two real costs:
+
+1. **Onboarding friction.** New users need to build whisper.cpp from source, download a model file, and wire paths into `.env`. The interactive `pidcast setup` wizard helps, but a non-trivial fraction of users abandon at this step.
+2. **Speed.** A 60-minute episode at `large-v3-turbo` takes 3–5 minutes on Apple Silicon and longer on older hardware. Cloud transcription is faster on the wall clock for the same hardware.
+
+ElevenLabs Scribe v2 emerged as a credible cloud alternative with built-in speaker diarization (no separate pyannote setup) and a forgiving rate limit.
+
+## Decision
+
+Support both providers behind a single `--transcription-provider {whisper,elevenlabs}` flag, with whisper as the default. Provider implementations live under `src/pidcast/providers/`. A common interface returns `(segments, speaker_turns_or_None)` so downstream code (`diarization.py`, `markdown.py`) is provider-agnostic.
+
+Diarization follows the same pluggability: whisper uses pyannote post-hoc, ElevenLabs reuses its own speakers — both surface through the same `--diarize` flag.
+
+## Consequences
+
+**Positive:**
+
+- New users can be productive in under 5 minutes with just an ElevenLabs API key. Local-first users keep their existing flow.
+- Workflow code is provider-agnostic. Future providers (Deepgram, AssemblyAI) plug into `providers/` without touching `workflow.py`.
+- The eval matrix in `data/evals/` can compare providers head-to-head on the same audio.
+
+**Negative:**
+
+- Two code paths to maintain and test. The `providers/` interface had to settle two divergent return shapes (whisper JSON vs. ElevenLabs API response). The reconciliation logic in `transcription.py` is non-obvious.
+- Provider-specific failure modes (whisper: missing model file; ElevenLabs: 401, 413 payload-too-large) need separate handling, including the chunked-synthesis retry path for 413 errors (commit `74cc00e`).
+- `pidcast doctor` has to know about both providers to give useful diagnostics.
+
+## Related code
+
+- `src/pidcast/providers/` — provider implementations
+- `src/pidcast/transcription.py` — dispatch and result normalization
+- `src/pidcast/diarization.py` — diarization merge across both paths
+- `tests/` — cross-provider speaker label consistency tests (commit `f340525`)

--- a/docs/adr/0002-llm-providers.md
+++ b/docs/adr/0002-llm-providers.md
@@ -1,0 +1,37 @@
+# ADR 0002 — Two LLM analysis providers behind one CLI flag
+
+**Status:** Accepted (2026-03-06, Claude provider landed in PR #9)
+
+## Context
+
+Analysis (summarization, key points, action items, comprehensive briefing) was Groq-only since the project's first release. Groq is fast and cheap, but two problems pushed for a second option:
+
+1. **Quality ceiling.** On long, dense audio (technical talks, multi-speaker debates), Groq's Llama 3.x outputs lose nuance compared to frontier models. A handful of evals (`data/evals/comparisons/`) confirmed the gap on accuracy and completeness scores.
+2. **No use of local Claude Code.** Many users already have an authenticated Claude Code CLI installed locally for other workflows. Reusing that subscription for pidcast analysis sidesteps yet another API key.
+
+## Decision
+
+Add `--provider claude` as a peer to `--provider groq` (default). The Claude path shells out to the local `claude` CLI, so it requires no Anthropic API key — it uses whatever auth the user already has set up for Claude Code. Model selection via `--claude-model {sonnet,opus,haiku}` (aliases that resolve to current Claude 4.x model IDs).
+
+Cost estimation is implemented per-provider (`config/models.yaml` carries pricing/rate-limit metadata) so the CLI can warn before a run rather than after.
+
+## Consequences
+
+**Positive:**
+
+- Quality ceiling lifted for users who care. Eval matrix scores on `comprehensive` analyses improved noticeably with `claude-opus`.
+- Zero-config for Claude Code users — no new API key, no new dashboard.
+- The dispatch layer in `analysis.py` is now provider-agnostic; adding a third provider (e.g. direct Anthropic API, OpenAI) is a small change.
+
+**Negative:**
+
+- Two prompt-execution code paths. Groq goes through the SDK; Claude shells out and parses the CLI's structured output. Errors look different and surface differently — `model_selector.py` has to handle both fallback chains.
+- Claude CLI must be installed and authenticated. `pidcast doctor` does not currently check Claude CLI presence — a known gap.
+- Cost estimation for the Claude path depends on the user's subscription model (Max, Pro, API), which the CLI cannot reliably introspect; estimates are approximate.
+
+## Related code
+
+- `src/pidcast/analysis.py`, `src/pidcast/summarization.py` — prompt execution
+- `src/pidcast/model_selector.py` — fallback chains and per-provider model lists
+- `config/models.yaml` — model definitions, rate limits, pricing
+- `src/pidcast/evals/` — provider comparison eval machinery

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,165 @@
+# Architecture
+
+pidcast is a single-shot CLI: given an input source, it produces a Markdown transcript with optional LLM analysis and writes it to disk (or an Obsidian vault). The same binary also manages a podcast library and runs batch syncs across subscribed feeds.
+
+This document maps the runtime data flow and the module boundaries. Start here when adding a feature that crosses module lines.
+
+## Data flow (single-shot path)
+
+```mermaid
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':60,'rankSpacing':80}}}%%
+flowchart TD
+    accTitle: pidcast single-shot transcription and analysis pipeline
+    accDescr: A URL or file is resolved to audio, normalized to WAV, transcribed by the chosen provider, optionally diarized, optionally analyzed by a Groq or Claude model, then written as Markdown to disk or an Obsidian vault. Run history and stats are persisted.
+
+    User([User]) -->|pidcast URL_OR_PATH| CLI{{cli.py}}
+    CLI --> Workflow{{workflow.py}}
+
+    Workflow --> Resolve{Input type?}
+    Resolve -->|YouTube / Apple Podcasts / RSS| Download(download.py)
+    Resolve -->|Local file| LocalAudio[/audio file/]
+    Resolve -->|Apple Podcasts URL| AP(apple_podcasts.py)
+    Resolve -->|RSS feed| RSS(rss.py)
+
+    Download --> Audio[/raw audio/]
+    AP --> Audio
+    RSS --> Audio
+    LocalAudio --> Audio
+
+    Audio --> Normalize(ffmpeg<br/>16kHz mono WAV)
+
+    Normalize --> ProviderPick{Transcription<br/>provider?}
+    ProviderPick -->|whisper| Whisper[[whisper.cpp]]
+    ProviderPick -->|elevenlabs| EL[[ElevenLabs Scribe v2]]
+
+    Whisper --> WhisperJSON[/whisper.json/]
+    EL --> ELOut[/segments + speakers/]
+
+    WhisperJSON --> DiarizeQ{--diarize?}
+    ELOut --> DiarizeQ
+    DiarizeQ -->|whisper + yes| Pyannote[[pyannote.audio]]
+    DiarizeQ -->|elevenlabs + yes| BuiltinSpk[built-in speakers]
+    DiarizeQ -->|no| Plain[plain segments]
+    Pyannote --> Merge(diarization.py)
+    BuiltinSpk --> Merge
+    Plain --> Merge
+
+    Merge --> AnalyzeQ{--no-analyze?}
+    AnalyzeQ -->|analyze| ChunkCheck{> 120k chars?}
+    AnalyzeQ -->|skip| Markdown(markdown.py)
+    ChunkCheck -->|yes| Chunking(chunking.py)
+    ChunkCheck -->|no| Analyze(analysis.py + summarization.py)
+    Chunking --> Analyze
+
+    Analyze --> LLM{LLM provider?}
+    LLM -->|groq| Groq[[Groq API]]
+    LLM -->|claude| Claude[[Claude Code CLI]]
+    Groq --> JSON[/analysis JSON/]
+    Claude --> JSON
+    JSON --> Markdown
+
+    Markdown --> Out{--save-to-obsidian?}
+    Out -->|yes| Vault[(Obsidian vault)]
+    Out -->|no| Disk[(data/transcripts/)]
+
+    Markdown --> Stats[(transcription_stats.json)]
+    Markdown --> History[(history.py)]
+
+    classDef storage fill:#ecfdf5,stroke:#16a34a,color:#064e3b;
+    classDef external fill:#fef3c7,stroke:#d97706,color:#78350f;
+    classDef orchestrator fill:#ede9fe,stroke:#7c3aed,color:#4c1d95;
+    class Vault,Disk,Stats,History storage;
+    class Whisper,EL,Pyannote,Groq,Claude external;
+    class CLI,Workflow orchestrator;
+
+    linkStyle default stroke:#64748b,stroke-width:1.5px
+```
+
+## Library subsystem
+
+Subscriptions to RSS feeds and Apple Podcasts shows live in a separate, persistent layer that drives batch processing.
+
+```mermaid
+%%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':60,'rankSpacing':70}}}%%
+flowchart LR
+    accTitle: pidcast library subsystem
+    accDescr: Library commands manage a YAML-backed list of podcast shows. Discovery searches Apple Podcasts and iTunes. Sync iterates shows, fetches new episodes, and dispatches each into the single-shot pipeline. A digest command summarizes processed episodes.
+
+    User([User]) -->|pidcast lib add| Add(lib add)
+    Add --> Discovery(discovery.py)
+    Discovery --> AppleDB[(Apple Podcasts SQLite)]
+    Discovery --> ITunes[[iTunes Search API]]
+    Add --> LibFile[(library.yaml)]
+
+    User -->|pidcast lib sync| Sync(sync.py)
+    Sync --> LibFile
+    Sync --> RSS(rss.py)
+    RSS --> Feed[[remote RSS feed]]
+    Sync --> Workflow{{workflow.py}}
+
+    User -->|pidcast lib digest| Digest(digest.py)
+    Digest --> Hist[(processing history)]
+
+    classDef storage fill:#ecfdf5,stroke:#16a34a,color:#064e3b;
+    classDef external fill:#fef3c7,stroke:#d97706,color:#78350f;
+    classDef orchestrator fill:#ede9fe,stroke:#7c3aed,color:#4c1d95;
+    class LibFile,AppleDB,Hist storage;
+    class ITunes,Feed external;
+    class Workflow,Sync orchestrator;
+
+    linkStyle default stroke:#64748b,stroke-width:1.5px
+```
+
+The library file lives at `~/.config/pidcast/library.yaml` (macOS/Linux) or `%APPDATA%\pidcast\library.yaml` (Windows) and is human-readable.
+
+## Component boundaries
+
+| Layer | Modules | Responsibility |
+|-------|---------|----------------|
+| **Entry** | `cli.py` | argparse surface, dispatch to workflow or `lib` subtree |
+| **Orchestration** | `workflow.py`, `sync.py` | sequence the pipeline steps for one input or for a batch |
+| **Input resolution** | `download.py`, `apple_podcasts.py`, `rss.py`, `discovery.py`, `cookies.py` | turn a URL or feed entry into a local audio file |
+| **Transcription** | `transcription.py`, `providers/` | provider-agnostic API over whisper.cpp and ElevenLabs |
+| **Speaker labeling** | `diarization.py` | merge pyannote or ElevenLabs speaker turns into the transcript |
+| **Analysis** | `analysis.py`, `summarization.py`, `chunking.py`, `model_selector.py` | prompt execution, JSON validation, semantic chunking, model fallback |
+| **Persistence** | `markdown.py`, `history.py`, `digest.py` | front matter, filenames, run stats, digest assembly |
+| **Library** | `library.py`, `sync.py` | YAML-backed podcast subscription store |
+| **Config/setup** | `config.py`, `config_manager.py`, `setup.py` | env loading, wizard, doctor checks |
+| **Cross-cutting** | `utils.py`, `exceptions.py` | filename smart-prefixes, duplicate detection, error types |
+
+## Provider abstractions
+
+Two pluggable axes:
+
+| Axis | Choices | Selector |
+|------|---------|----------|
+| Transcription | `whisper` (local, default), `elevenlabs` (cloud) | `--transcription-provider` |
+| LLM analysis | `groq` (default), `claude` (local Claude Code CLI) | `--provider` |
+
+Decisions behind these abstractions are recorded in [ADRs](adr/).
+
+## Audio pipeline invariant
+
+Every audio input is normalized to **16 kHz mono WAV** before transcription, regardless of source format (mp3, m4a, opus, wav, etc.). This is centralized in the ffmpeg helper invoked by `workflow.py` and by `scripts/diarize-existing.sh`. Modules downstream of normalization MUST assume this invariant — never re-derive sample rate or channel count from upstream metadata.
+
+## Chunking threshold
+
+Transcripts whose text length exceeds **120 000 characters** are routed through `chunking.py`, which splits on semantic boundaries (paragraphs > sentences), runs analysis per chunk, and synthesizes a final result. This threshold is empirical and lives in `config.py`; raise it cautiously because most Groq models have shorter usable contexts than the nominal token limit suggests.
+
+## Failure modes
+
+| Stage | Most common failure | Where it surfaces |
+|-------|--------------------|--------------------|
+| Download | YouTube `Sign in to confirm you're not a bot` | `download.py` — pass `--cookies-from-browser` or `--po-token` |
+| Audio normalize | `ffmpeg: command not found` | `pidcast doctor` flags it |
+| Transcription (whisper) | Missing model file | `pidcast doctor` flags it; `setup.py` can download |
+| Transcription (elevenlabs) | 401, 413 (payload too large) | `transcription.py` retries with smaller chunks for 413 |
+| Diarization | HUGGINGFACE_TOKEN missing or model license not accepted | Raises `DiarizationError`; see `--diarize-existing` to retry separately |
+| Analysis | Rate limit, JSON parse failure | `model_selector.py` falls back through `config/models.yaml` chain |
+
+## Related docs
+
+- [README.md](../README.md) — user-facing overview
+- [CLAUDE.md](../CLAUDE.md) — agent instructions, module map
+- [docs/development-guide.md](development-guide.md) — dev environment, testing, CI
+- [docs/adr/](adr/) — decision records

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -1,153 +1,130 @@
 # Development guide
 
-Generated: 2026-03-12 | Scan level: Quick
+How to set up a dev environment, run tests, and ship a change. For user-facing usage see [README.md](../README.md); for architecture see [architecture.md](architecture.md).
 
 ## Prerequisites
 
-- **Python** >=3.10
-- **uv** - Fast Python package manager ([install](https://astral.sh/uv/install.sh))
-- **ffmpeg** - Audio processing (install via system package manager)
-- **whisper.cpp** - Transcription engine ([build from source](https://github.com/ggerganov/whisper.cpp))
+- **Python ≥ 3.10**
+- **`uv`** — package manager ([install](https://docs.astral.sh/uv/getting-started/installation/))
+- **`ffmpeg`** — required for all audio paths (system package manager)
+- **`whisper.cpp`** — only if you want local transcription ([build from source](https://github.com/ggerganov/whisper.cpp)). Skip if you'll use ElevenLabs.
 
-## Environment setup
-
-1. Clone the repository:
-
-   ```bash
-   git clone https://github.com/kintecus/pidcast
-   cd pidcast
-   ```
-
-2. Install dependencies:
-
-   ```bash
-   uv sync          # Runtime dependencies
-   uv sync --group dev  # Include dev dependencies (ruff, pytest)
-   ```
-
-3. Configure environment:
-
-   ```bash
-   cp .env.example .env
-   # Edit .env with your API keys and tool paths
-   ```
-
-   Required variables:
-   - `GROQ_API_KEY` - Groq API key ([console.groq.com](https://console.groq.com/))
-   - `WHISPER_CPP_PATH` - Path to whisper.cpp binary
-   - `WHISPER_MODEL` - Path to Whisper model file
-
-   Optional variables:
-   - `OBSIDIAN_VAULT_PATH` - For `--save-to-obsidian` flag
-   - `HUGGINGFACE_TOKEN` - For speaker diarization (`--diarize`)
-   - `FFMPEG_PATH` - Custom ffmpeg path (defaults to `ffmpeg`)
-
-4. Set up pre-commit hooks:
-
-   ```bash
-   pre-commit install
-   ```
-
-## Running the tool
+## First-time setup
 
 ```bash
-# Main transcription
-uv run pidcast "https://youtube.com/watch?v=VIDEO_ID"
-
-# With analysis type
-uv run pidcast "VIDEO_URL" -a key_points
-
-# Skip analysis
-uv run pidcast "VIDEO_URL" --no-analyze
-
-# Local audio file
-uv run pidcast "/path/to/file.mp3"
-
-# Evaluation CLI
-uv run pidcast-eval --compare groq,claude --transcript-file transcript.txt
+git clone https://github.com/kintecus/pidcast
+cd pidcast
+uv sync --group dev          # runtime + dev deps (ruff, pytest)
+cp .env.example .env         # fill in keys
+uv run pidcast setup         # interactive wizard for paths and models
+pre-commit install           # ruff + mermaid validation on commit
 ```
 
-## Testing
+`pidcast setup` walks through whisper.cpp paths, model selection, and API keys. Run `pidcast doctor` at any time to check the current state of your tooling and env.
+
+## Environment variables
+
+Set in `.env`. See `.env.example` for the up-to-date list.
+
+| Variable | Purpose | Required? |
+|----------|---------|-----------|
+| `GROQ_API_KEY` | Default LLM provider for analysis | Required unless `--no-analyze` or `--provider claude` |
+| `ELEVENLABS_API_KEY` | ElevenLabs Scribe v2 transcription provider | Required if `--transcription-provider elevenlabs` |
+| `HUGGINGFACE_TOKEN` | Downloads pyannote diarization model on first use | Required for `--diarize` on the whisper path |
+| `WHISPER_CPP_PATH` | Path to `whisper-cli` binary | Required for local whisper transcription |
+| `WHISPER_MODEL` | Path to a `ggml-*.bin` model file | Required for local whisper transcription |
+| `FFMPEG_PATH` | Custom ffmpeg location | Optional (defaults to PATH lookup) |
+| `OBSIDIAN_VAULT_PATH` | Target vault root for `--save-to-obsidian` | Optional |
+
+## Running tests
 
 ```bash
-# Run all tests
-uv run pytest
-
-# Run specific test file
-uv run pytest tests/test_chunking.py
-
-# Verbose output
-uv run pytest -v
-
-# Run tests matching pattern
-uv run pytest -k "test_model"
+uv run pytest                              # full suite
+uv run pytest tests/test_chunking.py       # one file
+uv run pytest -k "test_model"              # name pattern
+uv run pytest -v                           # verbose
 ```
 
-Test configuration is in `pyproject.toml` under `[tool.pytest.ini_options]`.
+Test config is in `pyproject.toml` under `[tool.pytest.ini_options]`. Provider-specific tests are skipped when their API key is absent — set `ELEVENLABS_API_KEY=dummy` and `GROQ_API_KEY=dummy` in the test env if you want to run the offline shape checks without making real calls.
 
-## Code quality
+## Lint and format
 
 ```bash
-# Lint
-uv run ruff check src/
-
-# Auto-fix lint issues
-uv run ruff check --fix src/
-
-# Format
-uv run ruff format src/
-
-# Check formatting without changes
-uv run ruff format --check src/
+uv run ruff check src/                # lint
+uv run ruff check --fix src/          # autofix
+uv run ruff format src/               # format
+uv run ruff format --check src/       # CI-style check
 ```
 
-Ruff configuration is in `pyproject.toml` under `[tool.ruff]`:
+Ruff config lives in `pyproject.toml` under `[tool.ruff]`:
 
-- Target: Python 3.10
-- Line length: 100
-- Rules: E, W, F, I, N, UP, B, C4, SIM
+- Target Python 3.10
+- Line length 100
+- Rule set: `E, W, F, I, N, UP, B, C4, SIM`
+
+Pre-commit hook runs ruff and Mermaid syntax validation. Don't bypass with `--no-verify` — fix the underlying issue.
 
 ## Adding dependencies
 
 ```bash
-# Runtime dependency
-uv add package-name
-
-# Dev dependency
-uv add --dev package-name
-
-# Optional dependency group
-# Edit pyproject.toml [project.optional-dependencies] manually
-
-# Update all
-uv sync --upgrade
+uv add package-name              # runtime
+uv add --dev package-name        # dev only
+uv sync --upgrade                # bump all pins
 ```
+
+Optional dependency groups (e.g. `[diarize]`) live in `pyproject.toml` under `[project.optional-dependencies]`; edit manually.
 
 ## Project layout
 
 ```
-src/pidcast/          # Main package (src layout)
-config/               # External config (prompts, models)
-tests/                # Test suite
-data/                 # Runtime outputs (transcripts, evals, logs)
-docs/                 # Documentation
-scripts/              # Utility scripts
+src/pidcast/          # main package (src layout)
+  providers/          # transcription provider implementations
+  evals/              # pidcast-eval CLI for provider comparison
+config/               # prompts.yaml, models.yaml
+tests/                # pytest suite
+data/                 # runtime output (gitignored except eval references)
+  transcripts/        # canonical transcript location
+  evals/              # eval runs, references, comparisons
+docs/                 # this directory
+  adr/                # Architecture Decision Records
+scripts/              # diarize-existing.sh and other helpers
 ```
 
-## CI/CD
+## Project conventions
 
-GitHub Actions workflow (`.github/workflows/ci.yml`) runs on push/PR to main:
+- **Audio pipeline:** every audio input is normalized to 16 kHz mono WAV before transcription. Downstream modules MUST assume this invariant.
+- **LLM responses:** all analysis prompts return JSON with `analysis` and `contextual_tags` fields. Add fields via `config/prompts.yaml`, not via prompt-string surgery in code.
+- **Chunking threshold:** 120 000 characters triggers semantic chunking with synthesis. Threshold lives in `config.py`.
+- **Filenames:** smart-prefixed `YYYY-MM-DD_Title.md`. Logic in `utils.py`.
+- **Transcripts canonical location:** `data/transcripts/`. The repo gitignores stray `YYYY-MM-DD_*.md` files at the root.
 
-1. **Lint job** - `ruff check` + `ruff format --check`
-2. **Test job** - `pytest`
+## Provider comparison evals
 
-Both jobs use `uv sync --group dev` for dependency installation.
+`pidcast-eval` (entry point installed by `uv sync`) runs the same transcript through multiple providers and judges output quality with Claude Opus:
 
-## Conventions
+```bash
+uv run pidcast-eval --compare groq,claude --transcript-file transcript.txt --title "Episode Title"
+uv run pidcast-eval --run-matrix                              # all prompt × model × reference combos
+uv run pidcast-eval --run-matrix --models "llama-3.3-70b-versatile,mixtral-8x7b-32768"
+```
 
-- Use `ruff` for all linting and formatting
-- Follow src layout (`src/pidcast/`)
-- Audio pipeline standardizes to 16kHz mono WAV before transcription
-- All LLM responses use JSON mode with `analysis` and `contextual_tags` fields
-- Transcripts >120k chars use semantic chunking with synthesis
-- Smart filename filtering applies date prefixes (`YYYY-MM-DD_Title.md`)
+Results land in `data/evals/comparisons/` as Markdown reports. See `src/pidcast/evals/` for the underlying machinery.
+
+## CI
+
+GitHub Actions (`.github/workflows/ci.yml`) runs on push/PR to `main`:
+
+1. **Lint** — `ruff check` + `ruff format --check`
+2. **Test** — `pytest`
+
+Both jobs install with `uv sync --group dev`.
+
+## Plugin-driven automation
+
+This repo opts into several Claude Code plugins. Their config lives in `.claude-plugin/`:
+
+- `semver.json` — auto bumps `pyproject.toml` version on feature/fix commits (excludes `*.md`, `docs/**`)
+- `kb-grooming.json` — documentation health check scope
+- pre-commit hook in `.githooks/pre-commit` — ruff, PlantUML, and Mermaid validation
+
+The session entry points (`/semver:setup`, `/kb-grooming:kb-groom`, `/playbook:playbook-browse`) are usable from Claude Code but not from regular shells.


### PR DESCRIPTION
## Summary

The user-facing and agent-facing documentation had drifted significantly behind the codebase. This PR closes the gap.

- **User impact (README):** Visitors landing on the project now see an accurate description of what pidcast does (single-shot transcription + analysis, not just YouTube + Groq) and a clearly-marked Setup section that surfaces the interactive `pidcast setup` wizard and `pidcast doctor` command. Library subscriptions, ElevenLabs cloud transcription, and the Claude LLM provider — all shipped in the past 2–5 months — are documented instead of being inferable only from `--help` output. Length cut from 325 → 154 lines so it functions as a landing page rather than a manual.
- **Agent impact (CLAUDE.md):** Claude Code sessions now get an accurate module map (27 modules grouped by responsibility, vs. the old 10-module list) and an honest tech-stack section that lists both transcription providers and both LLM providers. The previously stale "YouTube transcription using Whisper and Groq" identity is gone.
- **New: `docs/architecture.md`** — Mermaid data-flow diagrams for the single-shot pipeline and the library subsystem, component-boundary table, audio-pipeline invariant, chunking threshold, and a per-stage failure-mode cheat sheet. Previously nothing of this kind existed.
- **New: `docs/adr/`** — Two Architecture Decision Records explaining *why* the codebase carries dual transcription and dual LLM paths. Context that was only reconstructable from git history is now in one place.
- **Tooling:** `.claude-plugin/kb-grooming.json` locks the documentation health-check scope to project docs, so future scans don't drown in `.venv/` and dependency READMEs.

## Methodology

Ran `kb-groom` against `main` to surface findings (saved to `/tmp/kb-grooming-report-2026-05-11.md`), then applied the `playbook/documentation-principles` and `playbook/readme` presets to drive the rewrite. Four commits, one per concern, for reviewability.

## Commits

1. `chore: scope kb-grooming to project docs only`
2. `docs: add architecture overview and ADRs for provider abstractions`
3. `docs: refresh CLAUDE.md to match current code surface`
4. `docs: refresh README and dev guide to current feature set`

## Open questions for follow-up

- **No `LICENSE` file exists** in the repo, even though the old README claimed "MIT". I removed the unsupported claim from the README; a real `LICENSE` file should be added separately.
- **Two parked branches with overlapping intent** — `docs/state-audit` (proposes `refactor!` to 1.0.0, prunes evals/digest/discovery) and `docs/add-architecture-reference` (proposes shrinking `cli.py` by 610 lines and removing `apple_podcasts.py`) were *not* merged in. They contain large source-level refactors, not just docs, and need separate product decisions. The architecture doc here describes the *current* codebase as-shipped; it can be revisited after those refactors land if they do.
- **`pidcast doctor` does not check Claude CLI** — flagged as a known gap in ADR-0002. Worth a small follow-up.

## Test plan

- [ ] Render `README.md` on GitHub — confirm motto blockquote renders as a callout, nav line emoji link to anchors, and the demo screenshot displays.
- [ ] Render `docs/architecture.md` on GitHub — confirm both Mermaid diagrams render (single-shot pipeline + library subsystem).
- [ ] From a fresh checkout, walk through the Installation + Setup sections and verify `uv run pidcast setup` and `uv run pidcast doctor` work as described.
- [ ] Click every internal doc link in the new README and CLAUDE.md (≈ 10 links) — confirm none 404.
- [ ] Run `kb-groom` again on this branch — confirm zero findings or only intentional deferrals.