### PR TITLE
fix: normalize hyphenated preset keys to argparse dests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidcast"
-version = "0.9.0"
+version = "0.9.1"
 description = "YouTube transcription tool with Whisper and LLM analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pidcast/cli.py
+++ b/src/pidcast/cli.py
@@ -200,12 +200,16 @@ def apply_preset(
     preset_values = ConfigManager.load_preset(args.preset)
 
     for key, value in preset_values.items():
-        if not hasattr(args, key):
+        # Preset keys may be written with hyphens (matching CLI flags like
+        # --transcription-provider) or underscores (matching argparse dests).
+        # Normalize to the dest form so both styles resolve.
+        dest = key.replace("-", "_")
+        if not hasattr(args, dest):
             logger.warning(f"Unknown preset key '{key}', skipping")
             continue
-        if key in explicitly_set:
+        if dest in explicitly_set:
             continue
-        setattr(args, key, value)
+        setattr(args, dest, value)
 
     if getattr(args, "verbose", False):
         logger.info(f"Applied preset '{args.preset}': {preset_values}")

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -113,6 +113,39 @@ class TestApplyPreset:
         assert args.whisper_model == "medium"  # NOT overridden
         assert args.language == "uk"  # set from preset
 
+    def test_hyphenated_preset_key_resolves_to_dest(self):
+        # Keys written with hyphens (matching CLI flags) should map to the
+        # underscore argparse dest. Regression: --transcription-provider was
+        # silently skipped when written as 'transcription-provider' in a preset.
+        args = argparse.Namespace(
+            preset="elabs",
+            transcription_provider="whisper",
+            keep_audio=False,
+            verbose=False,
+        )
+        preset_values = {
+            "transcription-provider": "elevenlabs",
+            "keep-audio": True,
+        }
+        with patch.object(ConfigManager, "load_preset", return_value=preset_values):
+            apply_preset(args)
+
+        assert args.transcription_provider == "elevenlabs"
+        assert args.keep_audio is True
+
+    def test_explicit_flag_overrides_hyphenated_preset_key(self):
+        args = argparse.Namespace(
+            preset="elabs",
+            transcription_provider="whisper",
+            verbose=False,
+        )
+        preset_values = {"transcription-provider": "elevenlabs"}
+        explicitly_set = {"transcription_provider"}
+        with patch.object(ConfigManager, "load_preset", return_value=preset_values):
+            apply_preset(args, explicitly_set=explicitly_set)
+
+        assert args.transcription_provider == "whisper"  # CLI flag wins
+
     def test_unknown_preset_key_warns(self, caplog):
         args = argparse.Namespace(
             preset="daily",


### PR DESCRIPTION
## What

Preset keys written with hyphens to mirror CLI flags (e.g. `transcription-provider`) were silently dropped. `apply_preset` checked each key against argparse **dest** names, which use underscores, so only keys whose flag and dest happened to match (`diarize`, `no_analyze`, `keep_audio`) applied. `transcription-provider` fell into the "unknown key" branch and the provider stayed at the `whisper` default.

## User impact

A preset that selected the ElevenLabs provider via `transcription-provider` was ignored, so transcription silently ran on **whisper** instead of the configured backend — with no error, only a WARNING-level log line. After this fix:

- Users get the transcription provider they configured in the preset.
- Preset keys can be written in **either** hyphen or underscore form, matching the flag names shown in `--help`. This removes the need to mentally translate `--transcription-provider` to `transcription_provider` when authoring a preset.

## Change

- `apply_preset` (`cli.py`): normalize each preset key with `key.replace("-", "_")` before resolving it to the argparse dest. Explicit CLI flags still override presets; genuinely unknown keys still warn, reporting the original string the user typed.
- Tests: added coverage for hyphenated keys resolving to dests, and for explicit flags overriding hyphenated preset keys.
- Bumped version `0.9.0` → `0.9.1` (PATCH, bug fix).

## Verification

- `uv run pytest tests/test_presets.py` → 10 passed
- `uv run ruff check src/pidcast/cli.py tests/test_presets.py` → clean
- Pre-commit hooks passed on commit.