### PR TITLE
fix: cap torch to 2.2.2 on Intel macs for the diarize extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidcast"
-version = "0.9.1"
+version = "0.9.2"
 description = "YouTube transcription tool with Whisper and LLM analysis"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -24,6 +24,12 @@ diarize = [
     "pyannote.audio>=3.3.0",
     "numpy<2",
     "huggingface-hub<1.0",
+    # torch>=2.3 dropped macOS x86_64 (Intel) wheels; 2.2.2 is the last build
+    # with one. Cap torch on Intel macs only so Linux/CI still resolve a modern
+    # torch. Without this, uv picks the newest torch and fails with "no wheel
+    # for the current platform" when installing the diarize extra.
+    "torch<=2.2.2; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "torchaudio<=2.2.2; sys_platform == 'darwin' and platform_machine == 'x86_64'",
 ]
 elevenlabs = [
     "elevenlabs>=2.0.0",


### PR DESCRIPTION
## What

`pyannote.audio` (the `diarize` extra) pulls `torch` transitively, and uv resolves to the newest release. **`torch>=2.3` dropped macOS x86_64 (Intel) wheels** — the latest with an Intel-Mac wheel is `2.2.2`. So on an Intel Mac, `uv sync --extra diarize` fails outright:

```
error: Distribution `torch==2.10.0` can't be installed because it doesn't
have a source distribution or wheel for the current platform
hint: You're on macOS (`macosx_15_0_x86_64`) ...
```

Diarization could not be installed at all on Intel Macs.

## Fix

Pin `torch` and `torchaudio` to `<=2.2.2` behind a platform marker:

```toml
"torch<=2.2.2; sys_platform == 'darwin' and platform_machine == 'x86_64'",
"torchaudio<=2.2.2; sys_platform == 'darwin' and platform_machine == 'x86_64'",
```

The marker scopes the cap to Intel Macs only, so **Linux and CI still resolve a modern torch** (where pyannote may need it).

## User impact

On Intel Macs, `pidcast --diarize` and `--diarize-existing` now install and run instead of failing at dependency resolution. Other platforms are unaffected.

## Verification

On `macosx_15_0_x86_64`:
- `uv sync --extra diarize --extra elevenlabs` → resolves to `torch==2.2.2`, installs `pyannote-audio==3.4.0`
- Imports clean: `pyannote 3.4.0 | torch 2.2.2 | elevenlabs 2.39.0`
- `uv run pytest` → **305 passed**

Bumped version `0.9.1` → `0.9.2` (PATCH).