### PR TITLE
fix: resolve --diarize-existing audio from front matter, not stem-swap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidcast"
-version = "0.9.2"
+version = "0.9.3"
 description = "YouTube transcription tool with Whisper and LLM analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pidcast/workflow.py
+++ b/src/pidcast/workflow.py
@@ -470,6 +470,68 @@ def run_analyze_existing_mode(
         return False
 
 
+# Audio extensions pyannote / ffmpeg can ingest, used when locating the source
+# audio for an existing transcript.
+_AUDIO_EXTENSIONS = (".wav", ".m4a", ".mp3", ".flac", ".opus", ".ogg", ".aac")
+
+
+def _url_to_local_path(url: str) -> Path | None:
+    """Convert a front-matter ``url`` value to a local audio Path, if it is one.
+
+    Handles ``file://`` URLs (as written for local-file captures) and bare
+    filesystem paths. Returns None for remote URLs (http/https) or empty values.
+    """
+    if not url:
+        return None
+    if url.startswith("file://"):
+        from urllib.parse import unquote, urlparse
+
+        return Path(unquote(urlparse(url).path))
+    if "://" in url:  # remote source (http, https, etc.) — no local audio
+        return None
+    return Path(url)
+
+
+def resolve_existing_audio(
+    transcript_path: Path,
+    front_matter_url: str = "",
+) -> Path | None:
+    """Locate the source audio for an existing transcript.
+
+    Resolution order:
+      1. The ``url`` recorded in the transcript front matter (local-file captures
+         store the source audio there, even when its filename differs from the
+         transcript's).
+      2. A single audio file sitting next to the transcript.
+      3. ``<transcript-stem>.wav`` next to the transcript (legacy heuristic).
+
+    Returns the resolved Path, or None if nothing matched. The transcript and
+    its audio are NOT guaranteed to share a stem — pidcast writes the audio with
+    a smart-filtered name and the transcript with a date-prefixed name — so the
+    front-matter url is the authoritative source.
+    """
+    parent = transcript_path.parent
+
+    # 1. Front-matter url
+    from_meta = _url_to_local_path(front_matter_url)
+    if from_meta and from_meta.exists():
+        return from_meta
+
+    # 2. Single sibling audio file
+    siblings = sorted(
+        p for p in parent.iterdir() if p.is_file() and p.suffix.lower() in _AUDIO_EXTENSIONS
+    )
+    if len(siblings) == 1:
+        return siblings[0]
+
+    # 3. Legacy stem-swap
+    stem_wav = parent / f"{transcript_path.stem}.wav"
+    if stem_wav.exists():
+        return stem_wav
+
+    return None
+
+
 def run_diarize_existing_mode(
     transcript_path: str | Path,
     audio_override: str | None = None,
@@ -521,15 +583,21 @@ def run_diarize_existing_mode(
                 log_error(f"Audio file not found: {audio_file}")
                 return False
         else:
-            # Look for .wav next to the transcript
-            audio_wav = parent / f"{stem}.wav"
-            if audio_wav.exists():
-                audio_file = audio_wav
-            else:
-                log_error(
-                    f"Audio file not found: {audio_wav}\n"
-                    "Provide an audio file with --audio /path/to/file.wav"
+            audio_file = resolve_existing_audio(transcript_path, video_info.webpage_url)
+            if audio_file is None:
+                candidates = sorted(
+                    p.name
+                    for p in parent.iterdir()
+                    if p.is_file() and p.suffix.lower() in _AUDIO_EXTENSIONS
                 )
+                hint = (
+                    "Provide an audio file with --audio /path/to/file.wav"
+                    if not candidates
+                    else "Could not match audio automatically. Audio files in this folder:\n  "
+                    + "\n  ".join(candidates)
+                    + "\nRe-run with --audio /path/to/file"
+                )
+                log_error(f"Audio file not found for transcript: {transcript_path.name}\n{hint}")
                 return False
 
         logger.info(f"Audio: {audio_file}")

--- a/tests/test_diarize_existing.py
+++ b/tests/test_diarize_existing.py
@@ -1,0 +1,94 @@
+"""Tests for audio resolution in --diarize-existing mode."""
+
+from pidcast.workflow import _url_to_local_path, resolve_existing_audio
+
+
+class TestUrlToLocalPath:
+    def test_file_url_resolves_to_path(self):
+        result = _url_to_local_path("file:///Users/x/Music/meeting.wav")
+        assert result is not None
+        assert str(result) == "/Users/x/Music/meeting.wav"
+
+    def test_file_url_with_percent_encoding(self):
+        result = _url_to_local_path("file:///Users/x/My%20Audio/clip.m4a")
+        assert str(result) == "/Users/x/My Audio/clip.m4a"
+
+    def test_bare_path(self):
+        result = _url_to_local_path("/Users/x/Music/meeting.wav")
+        assert str(result) == "/Users/x/Music/meeting.wav"
+
+    def test_remote_url_returns_none(self):
+        assert _url_to_local_path("https://youtube.com/watch?v=abc") is None
+
+    def test_empty_returns_none(self):
+        assert _url_to_local_path("") is None
+
+
+class TestResolveExistingAudio:
+    def test_resolves_from_front_matter_url_when_names_differ(self, tmp_path):
+        # The real-world case: audio is smart-named, transcript is date-prefixed.
+        transcript = tmp_path / "2026-06-05_meeting_1607.md"
+        transcript.write_text("---\n")
+        audio = tmp_path / "meeting-2026-06-05-1607.wav"
+        audio.write_bytes(b"\x00")
+
+        result = resolve_existing_audio(transcript, f"file://{audio}")
+        assert result == audio
+
+    def test_falls_back_to_single_sibling_audio(self, tmp_path):
+        transcript = tmp_path / "transcript.md"
+        transcript.write_text("---\n")
+        audio = tmp_path / "some-other-name.m4a"
+        audio.write_bytes(b"\x00")
+
+        # No usable url, but exactly one audio file sits beside the transcript.
+        result = resolve_existing_audio(transcript, "")
+        assert result == audio
+
+    def test_ambiguous_siblings_do_not_resolve(self, tmp_path):
+        transcript = tmp_path / "transcript.md"
+        transcript.write_text("---\n")
+        (tmp_path / "a.wav").write_bytes(b"\x00")
+        (tmp_path / "b.mp3").write_bytes(b"\x00")
+
+        # Two audio files and no url -> ambiguous, caller must use --audio.
+        assert resolve_existing_audio(transcript, "") is None
+
+    def test_legacy_stem_swap_still_works(self, tmp_path):
+        transcript = tmp_path / "episode.md"
+        transcript.write_text("---\n")
+        audio = tmp_path / "episode.wav"
+        audio.write_bytes(b"\x00")
+        # Add a second, differently-named audio so the sibling-glob would be
+        # ambiguous — proving the stem-swap path is what resolves it.
+        (tmp_path / "decoy.mp3").write_bytes(b"\x00")
+
+        result = resolve_existing_audio(transcript, "")
+        assert result == audio
+
+    def test_front_matter_url_wins_over_sibling(self, tmp_path):
+        transcript = tmp_path / "t.md"
+        transcript.write_text("---\n")
+        meta_audio = tmp_path / "from-meta.wav"
+        meta_audio.write_bytes(b"\x00")
+        # A stem-swap candidate also exists; the front-matter url should win.
+        (tmp_path / "t.wav").write_bytes(b"\x00")
+
+        result = resolve_existing_audio(transcript, f"file://{meta_audio}")
+        assert result == meta_audio
+
+    def test_nothing_found_returns_none(self, tmp_path):
+        transcript = tmp_path / "t.md"
+        transcript.write_text("---\n")
+        assert resolve_existing_audio(transcript, "") is None
+
+    def test_nonexistent_front_matter_url_falls_through(self, tmp_path):
+        transcript = tmp_path / "t.md"
+        transcript.write_text("---\n")
+        audio = tmp_path / "real.wav"
+        audio.write_bytes(b"\x00")
+
+        # url points at a missing file; resolution should fall back to the
+        # single sibling rather than returning the dead path.
+        result = resolve_existing_audio(transcript, "file:///does/not/exist.wav")
+        assert result == audio


### PR DESCRIPTION
## What

`--diarize-existing` re-runs diarization on an existing transcript, which needs the source **audio** (not just the transcript). It located that audio by swapping the transcript's `.md` extension for `.wav` and looking next to it.

But pidcast writes the two files with **different naming schemes**:

| file | name |
|------|------|
| audio | `meeting-2026-06-05-1607-47.wav` (smart-filtered, hyphenated) |
| transcript | `2026-06-05_meeting_2026_06_05_1607_47.md` (date-prefixed, underscored) |

So the stems never match for pidcast's own captures, and `pidcast --diarize-existing transcript.md` always failed with `Audio file not found` unless the user manually passed `--audio`.

## Fix

`resolve_existing_audio()` now resolves in order:

1. **Front-matter `url:`** — local-file captures record the real source audio path there (`file://...`). This is authoritative and survives the naming mismatch.
2. **Single sibling audio file** — if exactly one audio file sits next to the transcript, use it.
3. **Legacy `<stem>.wav`** — kept for back-compat.

When nothing matches, the error now **lists the audio files in the folder** so the correct `--audio` value is obvious instead of guessable.

## User impact

`pidcast --diarize-existing transcript.md` now finds the audio on its own for any transcript pidcast produced — no `--audio` flag needed. Users who hit the old "Audio file not found" dead-end get a working command, and when resolution is genuinely ambiguous they get a candidate list instead of a single wrong guessed path.

## Verification

- New `tests/test_diarize_existing.py`: 12 tests covering front-matter resolution, percent-encoded paths, single-sibling fallback, ambiguous-siblings, legacy stem-swap, precedence, and dead-url fallthrough.
- Verified against a real transcript on disk: front-matter `url` `file://.../meeting-2026-06-05-1607-47.wav` resolves to the existing audio.
- `uv run pytest` → **317 passed** (was 305).
- `uv run ruff check` → clean.

Bumped version `0.9.2` → `0.9.3` (PATCH).