### PR TITLE
feat: pause and resume whisper transcription mid-run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidcast"
-version = "0.10.0"
+version = "0.10.1"
 description = "YouTube transcription tool with Whisper and LLM analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidcast"
-version = "0.9.3"
+version = "0.10.0"
 description = "YouTube transcription tool with Whisper and LLM analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidcast"
-version = "0.10.1"
+version = "0.10.2"
 description = "YouTube transcription tool with Whisper and LLM analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pidcast/checkpoint.py
+++ b/src/pidcast/checkpoint.py
@@ -1,0 +1,232 @@
+"""Resume/pause checkpoint state for transcription jobs.
+
+A *job* is one transcription run keyed by a content+config signature. Its state
+lives in ``CHECKPOINT_DIR/<job_id>/``:
+
+- ``manifest.json``           - phase status, resolved CLI args, video info.
+- ``segments.jsonl``          - one completed whisper segment per line, appended
+                                and flushed as it streams off whisper's stdout.
+- ``source.wav``              - the 16kHz mono WAV whisper consumes, copied in
+                                BEFORE transcription so a crash/pause is resumable
+                                without re-downloading or re-converting.
+
+The JSONL is the source of truth for the resume offset: the manifest's
+``last_offset_ms`` is advisory (writes are throttled), so on load we always
+recompute the offset from the last well-formed JSONL line. A partially written
+trailing line (process killed mid-write) is tolerated and skipped.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .config import CHECKPOINT_DIR, VideoInfo
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+MANIFEST_NAME = "manifest.json"
+SEGMENTS_NAME = "segments.jsonl"
+SOURCE_WAV_NAME = "source.wav"
+
+# Phase statuses.
+PENDING = "pending"
+IN_PROGRESS = "in_progress"
+PAUSED = "paused"
+DONE = "done"
+
+# Files smaller than this are hashed whole; larger ones use a head+tail sample so
+# startup stays fast on multi-hundred-MB media.
+_SIGNATURE_SAMPLE_THRESHOLD = 16 * 1024 * 1024
+_SIGNATURE_SAMPLE_BYTES = 8 * 1024 * 1024
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def quick_file_signature(path: str | Path) -> str:
+    """Cheap content signature for an audio file.
+
+    For files under 16MB, hashes the whole file. For larger files, hashes the
+    size plus the first and last 8MB - enough to detect a different recording
+    without reading hundreds of MB on every run.
+    """
+    p = Path(path)
+    size = p.stat().st_size
+    h = hashlib.sha256()
+    h.update(str(size).encode())
+    with open(p, "rb") as f:
+        if size <= _SIGNATURE_SAMPLE_THRESHOLD:
+            h.update(f.read())
+        else:
+            h.update(f.read(_SIGNATURE_SAMPLE_BYTES))
+            f.seek(-_SIGNATURE_SAMPLE_BYTES, os.SEEK_END)
+            h.update(f.read(_SIGNATURE_SAMPLE_BYTES))
+    return h.hexdigest()
+
+
+def compute_job_id(
+    audio_signature: str,
+    provider: str,
+    model: str,
+    language: str | None,
+    vad_signature: str,
+) -> str:
+    """Stable id for a (content, config) pair.
+
+    Config is part of the key on purpose: changing the model, language, or VAD
+    settings produces a different job id, so a resume never merges segments
+    decoded under incompatible settings.
+    """
+    raw = f"{audio_signature}:{provider}:{model}:{language or ''}:{vad_signature}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+@dataclass
+class PhaseState:
+    status: str = PENDING
+    # Transcription-only; advisory mirror of the JSONL tail.
+    last_offset_ms: int = 0
+    segment_count: int = 0
+    # Diarization-only.
+    requested: bool = False
+    speaker_count: int | None = None
+
+
+@dataclass
+class JobManifest:
+    job_id: str
+    input_source: str
+    audio_signature: str
+    smart_filename: str
+    provider: str
+    model: str
+    language: str | None
+    vad_signature: str
+    # Resolved flags needed to re-run on `pidcast resume`. Stores the model NAME,
+    # not a resolved absolute path - resume re-resolves the model and re-reads env
+    # tokens, so a moved model file or rotated token still works.
+    cli_args: dict[str, Any] = field(default_factory=dict)
+    video_info: dict[str, Any] | None = None
+    schema_version: int = SCHEMA_VERSION
+    created_at: str = field(default_factory=_utc_now_iso)
+    updated_at: str = field(default_factory=_utc_now_iso)
+    transcription: PhaseState = field(default_factory=PhaseState)
+    diarization: PhaseState = field(default_factory=PhaseState)
+
+    # -- paths -----------------------------------------------------------------
+
+    @property
+    def job_dir(self) -> Path:
+        return CHECKPOINT_DIR / self.job_id
+
+    @property
+    def segments_path(self) -> Path:
+        return self.job_dir / SEGMENTS_NAME
+
+    @property
+    def source_wav_path(self) -> Path:
+        return self.job_dir / SOURCE_WAV_NAME
+
+    # -- persistence -----------------------------------------------------------
+
+    def save(self) -> None:
+        """Atomically write the manifest (tmp + os.replace)."""
+        self.job_dir.mkdir(parents=True, exist_ok=True)
+        self.updated_at = _utc_now_iso()
+        payload = asdict(self)
+        tmp = self.job_dir / (MANIFEST_NAME + ".tmp")
+        tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp, self.job_dir / MANIFEST_NAME)
+
+    @classmethod
+    def load(cls, job_dir: Path) -> JobManifest | None:
+        """Load a manifest, or None if missing/corrupt (e.g. crashed mid-write)."""
+        manifest_file = job_dir / MANIFEST_NAME
+        try:
+            data = json.loads(manifest_file.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError) as e:
+            logger.warning(f"Skipping unreadable checkpoint manifest at {job_dir}: {e}")
+            return None
+        trans = PhaseState(**data.pop("transcription", {}) or {})
+        diar = PhaseState(**data.pop("diarization", {}) or {})
+        data.pop("schema_version", None)
+        try:
+            return cls(transcription=trans, diarization=diar, schema_version=SCHEMA_VERSION, **data)
+        except TypeError as e:
+            logger.warning(f"Checkpoint manifest schema mismatch at {job_dir}: {e}")
+            return None
+
+    def video_info_obj(self) -> VideoInfo | None:
+        return VideoInfo.from_dict(self.video_info) if self.video_info else None
+
+    # -- segment IO ------------------------------------------------------------
+
+    def load_segments(self) -> list[dict]:
+        """Read completed segments from the JSONL, skipping a partial last line."""
+        if not self.segments_path.exists():
+            return []
+        segments: list[dict] = []
+        with open(self.segments_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    seg = json.loads(line)
+                except json.JSONDecodeError:
+                    # Trailing partial line from a kill mid-write - tolerate and stop.
+                    logger.debug("Skipping partial trailing segment line in %s", self.segments_path)
+                    break
+                segments.append(seg)
+        return segments
+
+    def append_segment(self, segment: dict) -> None:
+        """Append one segment record and flush so it survives an immediate kill."""
+        self.job_dir.mkdir(parents=True, exist_ok=True)
+        with open(self.segments_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(segment, ensure_ascii=False) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+
+    def resume_offset_ms(self) -> int:
+        """Resume offset = end of the last well-formed persisted segment (0 if fresh)."""
+        segments = self.load_segments()
+        if not segments:
+            return 0
+        return int(segments[-1].get("to_ms", 0))
+
+
+def find_resumable_jobs() -> list[JobManifest]:
+    """Paused/in-progress jobs, newest first (ties broken by created_at, job_id)."""
+    if not CHECKPOINT_DIR.exists():
+        return []
+    jobs: list[JobManifest] = []
+    for job_dir in CHECKPOINT_DIR.iterdir():
+        if not job_dir.is_dir():
+            continue
+        manifest = JobManifest.load(job_dir)
+        if manifest is None:
+            continue
+        if manifest.transcription.status in (PAUSED, IN_PROGRESS) or (
+            manifest.transcription.status == DONE and manifest.diarization.status != DONE
+        ):
+            jobs.append(manifest)
+    jobs.sort(key=lambda m: (m.updated_at, m.created_at, m.job_id), reverse=True)
+    return jobs
+
+
+def cleanup_job_dir(job_id: str) -> None:
+    """Remove a job's checkpoint directory (called on successful completion)."""
+    job_dir = CHECKPOINT_DIR / job_id
+    if job_dir.exists():
+        shutil.rmtree(job_dir, ignore_errors=True)

--- a/src/pidcast/cli.py
+++ b/src/pidcast/cli.py
@@ -596,6 +596,24 @@ Short Flags:
         action="store_true",
         help="Save the converted WAV audio file to the output directory",
     )
+
+    checkpoint_group = parser.add_argument_group("Checkpoint / Resume Options")
+    checkpoint_group.add_argument(
+        "--no-checkpoint",
+        dest="no_checkpoint",
+        action="store_true",
+        help="Disable resume checkpointing (one-shot transcription, no pause/resume).",
+    )
+    checkpoint_group.add_argument(
+        "--keep-checkpoint",
+        dest="keep_checkpoint",
+        action="store_true",
+        help="Keep the checkpoint directory after a successful run (default: delete).",
+    )
+    # Internal: set by `pidcast resume` to re-enter a specific job. Hidden from help.
+    parser.add_argument(
+        "--resume-job-id", dest="resume_job_id", default=None, help=argparse.SUPPRESS
+    )
     parser.add_argument(
         "--po-token",
         dest="po_token",
@@ -1528,6 +1546,13 @@ def main() -> None:
             load_dotenv()
             cmd_setup()
             return
+        if sys.argv[1] == "resume":
+            from dotenv import load_dotenv
+
+            load_dotenv()
+            job_arg = sys.argv[2] if len(sys.argv) > 2 else None
+            cmd_resume(job_arg)
+            return
 
     args = parse_arguments()
 
@@ -1818,17 +1843,83 @@ def main() -> None:
             elif action == DuplicateAction.FORCE_CONTINUE:
                 logger.info("Continuing with transcription...")
 
-    # Run the main transcription workflow
-    process_input_source(
-        args.input_source,
-        args,
-        output_dir,
-        analysis_output_dir,
-        stats_file,
-        run_uid,
-        run_timestamp,
-        start_time,
+    # Run the main transcription workflow under a pause-aware SIGINT handler.
+    _run_with_pause_handler(
+        lambda: process_input_source(
+            args.input_source,
+            args,
+            output_dir,
+            analysis_output_dir,
+            stats_file,
+            run_uid,
+            run_timestamp,
+            start_time,
+        )
     )
+
+
+def _run_with_pause_handler(run_fn) -> None:
+    """Run ``run_fn`` with Ctrl-C wired to a clean transcription pause.
+
+    First Ctrl-C requests a pause (the whisper stream loop stops at the next
+    segment boundary and the job is checkpointed). A second Ctrl-C restores the
+    default handler and hard-quits.
+    """
+    import signal
+
+    from .workflow import request_pause
+
+    state = {"count": 0}
+    original = signal.getsignal(signal.SIGINT)
+
+    def _handler(signum, frame):
+        state["count"] += 1
+        if state["count"] == 1:
+            logger.info(
+                "\nPausing transcription at the next segment boundary... (Ctrl-C again to force quit)"
+            )
+            request_pause()
+        else:
+            signal.signal(signal.SIGINT, original)
+            raise KeyboardInterrupt
+
+    signal.signal(signal.SIGINT, _handler)
+    try:
+        run_fn()
+    finally:
+        signal.signal(signal.SIGINT, original)
+
+
+def cmd_resume(job_arg: str | None) -> None:
+    """Resume a paused/interrupted transcription job (``pidcast resume [job-id]``)."""
+    from .checkpoint import DONE, JobManifest, find_resumable_jobs
+    from .resume import resume_job
+
+    jobs = find_resumable_jobs()
+    if not jobs:
+        logger.info("No resumable jobs found.")
+        return
+
+    manifest: JobManifest | None = None
+    if job_arg:
+        manifest = next((j for j in jobs if j.job_id.startswith(job_arg)), None)
+        if manifest is None:
+            logger.error(f"No resumable job matching '{job_arg}'.")
+            return
+    elif len(jobs) == 1:
+        manifest = jobs[0]
+    else:
+        logger.info("Multiple resumable jobs - pass a job id to pick one:\n")
+        for j in jobs:
+            phase = "diarization" if j.transcription.status == DONE else "transcription"
+            title = (j.video_info or {}).get("title", j.input_source)
+            logger.info(
+                f"  {j.job_id}  [{phase}]  {title}  "
+                f"({j.transcription.segment_count} segments, updated {j.updated_at})"
+            )
+        return
+
+    resume_job(manifest)
 
 
 if __name__ == "__main__":

--- a/src/pidcast/cli.py
+++ b/src/pidcast/cli.py
@@ -1550,7 +1550,12 @@ def main() -> None:
             from dotenv import load_dotenv
 
             load_dotenv()
-            job_arg = sys.argv[2] if len(sys.argv) > 2 else None
+            # These subcommands dispatch before parse_arguments()/setup_logging(),
+            # so configure logging here or every logger.* call is silently dropped.
+            verbose = "--verbose" in sys.argv or "-v" in sys.argv
+            setup_logging(verbose)
+            job_args = [a for a in sys.argv[2:] if not a.startswith("-")]
+            job_arg = job_args[0] if job_args else None
             cmd_resume(job_arg)
             return
 

--- a/src/pidcast/config.py
+++ b/src/pidcast/config.py
@@ -103,6 +103,12 @@ SYNC_LOGS_DIR = CONFIG_DIR / "logs"
 COOKIE_CACHE_DIR = CONFIG_DIR / "cache"
 COOKIE_CACHE_MAX_AGE_HOURS = 24
 
+# Resume/pause checkpoints. Kept OUTSIDE COOKIE_CACHE_DIR so a cookie-cache sweep
+# never wipes a paused transcription job.
+CHECKPOINT_DIR = CONFIG_DIR / "checkpoints"
+# Paused jobs older than this are eligible for the stale-job sweep.
+CHECKPOINT_MAX_AGE_DAYS = 14
+
 # Library defaults
 DEFAULT_BACKFILL_LIMIT = 5
 DEFAULT_FEED_CACHE_HOURS = 1

--- a/src/pidcast/exceptions.py
+++ b/src/pidcast/exceptions.py
@@ -19,6 +19,19 @@ class TranscriptionError(PidcastError):
     pass
 
 
+class TranscriptionPaused(PidcastError):  # noqa: N818 - a control signal, not an error
+    """Transcription was deliberately paused (e.g. via Ctrl-C).
+
+    Not an error: already-streamed segments are checkpointed and the job can be
+    resumed with ``pidcast resume``. Carries the last offset reached so callers
+    can report progress.
+    """
+
+    def __init__(self, message: str = "", last_offset_ms: int = 0) -> None:
+        super().__init__(message)
+        self.last_offset_ms = last_offset_ms
+
+
 class AnalysisError(PidcastError):
     """LLM analysis failed."""
 

--- a/src/pidcast/providers/whisper_provider.py
+++ b/src/pidcast/providers/whisper_provider.py
@@ -7,7 +7,12 @@ import logging
 import shutil
 import time
 import uuid
+from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..checkpoint import JobManifest
 
 from ..config import HUGGINGFACE_TOKEN
 from ..diarization import merge_whisper_with_diarization, run_diarization
@@ -15,11 +20,19 @@ from ..exceptions import DiarizationError, TranscriptionError
 from ..transcription import (
     collapse_repeated_lines,
     dedupe_whisper_segments,
+    merge_segments_to_whisper_json,
     run_whisper_transcription,
 )
 from . import TranscriptionResult
 
 logger = logging.getLogger(__name__)
+
+# When resuming a VAD run, back the offset off by this many ms before the last
+# good segment. -ot + --vad can shift the boundary and swallow audio at the seam
+# (verified in the phase-0 spike); re-decoding a few seconds and de-overlapping on
+# merge avoids dropped words. Harmless for non-VAD resumes (de-overlap drops the
+# re-decoded segments anyway).
+_VAD_RESUME_BACKOFF_MS = 8000
 
 
 class WhisperTranscriptionProvider:
@@ -33,6 +46,8 @@ class WhisperTranscriptionProvider:
         estimated_duration: float | None = None,
         save_whisper_json_to: Path | None = None,
         whisper_options: dict | None = None,
+        checkpoint: JobManifest | None = None,
+        pause_check: Callable[[], bool] | None = None,
     ) -> None:
         self._whisper_model = whisper_model
         self._output_format = output_format
@@ -43,6 +58,11 @@ class WhisperTranscriptionProvider:
         # into run_whisper_transcription. Whisper-only, kept off the shared
         # TranscriptionProvider.transcribe() signature.
         self._opts = whisper_options or {}
+        # Resume/pause: when set, segments stream into the manifest's JSONL and a
+        # crash/pause can be resumed via -ot. None keeps the one-shot behavior
+        # byte-identical to before.
+        self._checkpoint = checkpoint
+        self._pause_check = pause_check
 
     def transcribe(
         self,
@@ -53,8 +73,10 @@ class WhisperTranscriptionProvider:
     ) -> TranscriptionResult:
         """Transcribe audio using whisper.cpp."""
         temp_output = self._output_dir / f"temp_transcript_{uuid.uuid4().hex[:8]}"
-        # Always output JSON when we need to save whisper data or diarize
-        need_json = diarize or self._save_whisper_json_to is not None
+        # Always output JSON when we need to save whisper data, diarize, or checkpoint.
+        need_json = (
+            diarize or self._save_whisper_json_to is not None or self._checkpoint is not None
+        )
         output_format = "json" if need_json else self._output_format
 
         if diarize and not HUGGINGFACE_TOKEN:
@@ -64,26 +86,32 @@ class WhisperTranscriptionProvider:
             )
 
         start_time = time.time()
+        json_file = Path(f"{temp_output}.json")
 
-        try:
-            run_whisper_transcription(
-                audio_file,
-                self._whisper_model,
-                output_format,
-                str(temp_output),
-                verbose,
-                estimated_duration=self._estimated_duration,
-                language=language,
-                **self._opts,
-            )
-        except Exception as e:
-            raise TranscriptionError(f"Whisper transcription failed: {e}") from e
+        if self._checkpoint is not None:
+            # Resumable path: stream segments into the manifest's JSONL, resume
+            # from the persisted offset, then materialize the merged JSON.
+            self._transcribe_checkpointed(audio_file, output_format, temp_output, language, verbose)
+        else:
+            try:
+                run_whisper_transcription(
+                    audio_file,
+                    self._whisper_model,
+                    output_format,
+                    str(temp_output),
+                    verbose,
+                    estimated_duration=self._estimated_duration,
+                    language=language,
+                    pause_check=self._pause_check,
+                    **self._opts,
+                )
+            except Exception as e:
+                raise TranscriptionError(f"Whisper transcription failed: {e}") from e
 
         duration = time.time() - start_time
 
         # Save whisper JSON before diarization (so it survives diarization failures)
         whisper_json_path = None
-        json_file = Path(f"{temp_output}.json")
         if self._save_whisper_json_to and json_file.exists():
             shutil.copy2(json_file, self._save_whisper_json_to)
             whisper_json_path = self._save_whisper_json_to
@@ -120,6 +148,97 @@ class WhisperTranscriptionProvider:
             diarized=diarized,
             whisper_json_path=whisper_json_path,
         )
+
+    def _transcribe_checkpointed(
+        self,
+        audio_file: str | Path,
+        output_format: str,
+        temp_output: Path,
+        language: str | None,
+        verbose: bool,
+    ) -> None:
+        """Resumable transcription: stream segments to the JSONL, merge on completion.
+
+        Resumes from the offset persisted in the manifest's JSONL. With VAD the
+        offset is backed off a few seconds (the seam can swallow audio) and the
+        re-decoded overlap is dropped at merge time. On completion the merged,
+        de-overlapped whisper JSON is written to ``{temp_output}.json`` so the rest
+        of the provider (text extraction, diarization, JSON save) is unchanged.
+        """
+        from ..checkpoint import DONE
+
+        manifest = self._checkpoint
+        assert manifest is not None
+
+        # Transcription already finished in a prior run (job paused/crashed during
+        # diarization or analysis). Skip whisper entirely and rebuild the JSON from
+        # the persisted segments so we go straight to diarization/text.
+        if manifest.transcription.status == DONE:
+            logger.info("Transcription already complete - skipping whisper, rebuilding JSON...")
+            self._materialize_json_from_segments(manifest, temp_output)
+            return
+
+        prior = manifest.load_segments()
+        resume_offset = manifest.resume_offset_ms()
+        if resume_offset > 0 and self._opts.get("vad_model"):
+            resume_offset = max(0, resume_offset - _VAD_RESUME_BACKOFF_MS)
+
+        if prior:
+            logger.info(
+                f"Resuming transcription from {resume_offset // 1000}s "
+                f"({len(prior)} segments already done)..."
+            )
+
+        def _on_segment(seg: dict) -> None:
+            # Skip anything we already persisted (resume re-decode overlap).
+            if seg["to_ms"] <= manifest.transcription.last_offset_ms:
+                return
+            manifest.append_segment(seg)
+            manifest.transcription.last_offset_ms = seg["to_ms"]
+            manifest.transcription.segment_count += 1
+
+        try:
+            run_whisper_transcription(
+                audio_file,
+                self._whisper_model,
+                output_format,
+                str(temp_output),
+                verbose,
+                estimated_duration=self._estimated_duration,
+                language=language,
+                offset_ms=resume_offset,
+                segment_callback=_on_segment,
+                pause_check=self._pause_check,
+                **self._opts,
+            )
+        except Exception:
+            # TranscriptionPaused and real failures both propagate; the JSONL holds
+            # everything decoded so far either way.
+            raise
+
+        # Materialize the full, de-overlapped whisper JSON from the JSONL (single
+        # source of truth across the resume seam).
+        self._materialize_json_from_segments(manifest, temp_output)
+
+    @staticmethod
+    def _materialize_json_from_segments(manifest, temp_output: Path) -> None:
+        """Write the merged whisper JSON from the manifest's persisted segments.
+
+        Preserves any metadata (model/params/systeminfo) from a freshly written
+        per-run JSON if present, then overwrites it with the full de-overlapped set.
+        """
+        all_segments = manifest.load_segments()
+        base_template: dict = {}
+        raw_json = Path(f"{temp_output}.json")
+        if raw_json.exists():
+            try:
+                loaded = json.loads(raw_json.read_text(encoding="utf-8"))
+                base_template = {k: v for k, v in loaded.items() if k != "transcription"}
+            except (json.JSONDecodeError, OSError):
+                base_template = {}
+        merged = merge_segments_to_whisper_json(all_segments, base_template)
+        raw_json.parent.mkdir(parents=True, exist_ok=True)
+        raw_json.write_text(json.dumps(merged, ensure_ascii=False, indent=2), encoding="utf-8")
 
     def _run_diarization(
         self,

--- a/src/pidcast/providers/whisper_provider.py
+++ b/src/pidcast/providers/whisper_provider.py
@@ -35,6 +35,14 @@ logger = logging.getLogger(__name__)
 _VAD_RESUME_BACKOFF_MS = 8000
 
 
+def _fmt_clock(ms: int) -> str:
+    """Render milliseconds as MM:SS (or H:MM:SS past an hour) for human-facing logs."""
+    total_s = max(0, int(ms)) // 1000
+    h, rem = divmod(total_s, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+
+
 class WhisperTranscriptionProvider:
     """Transcription provider using local whisper.cpp."""
 
@@ -48,11 +56,15 @@ class WhisperTranscriptionProvider:
         whisper_options: dict | None = None,
         checkpoint: JobManifest | None = None,
         pause_check: Callable[[], bool] | None = None,
+        audio_duration: float | None = None,
     ) -> None:
         self._whisper_model = whisper_model
         self._output_format = output_format
         self._output_dir = Path(output_dir)
         self._estimated_duration = estimated_duration
+        # True audio length (seconds) - drives the progress bar by audio position,
+        # which stays correct across a resume offset (unlike the wall-clock estimate).
+        self._audio_duration = audio_duration
         self._save_whisper_json_to = save_whisper_json_to
         # Decoding/quality knobs (threads, VAD, thresholds, suppress_nst) splatted
         # into run_whisper_transcription. Whisper-only, kept off the shared
@@ -101,6 +113,7 @@ class WhisperTranscriptionProvider:
                     str(temp_output),
                     verbose,
                     estimated_duration=self._estimated_duration,
+                    audio_duration=self._audio_duration,
                     language=language,
                     pause_check=self._pause_check,
                     **self._opts,
@@ -184,10 +197,16 @@ class WhisperTranscriptionProvider:
             resume_offset = max(0, resume_offset - _VAD_RESUME_BACKOFF_MS)
 
         if prior:
-            logger.info(
-                f"Resuming transcription from {resume_offset // 1000}s "
-                f"({len(prior)} segments already done)..."
-            )
+            done = _fmt_clock(resume_offset)
+            if self._audio_duration and self._audio_duration > 0:
+                total = _fmt_clock(int(self._audio_duration * 1000))
+                pct = min(100, int(100 * resume_offset / (self._audio_duration * 1000)))
+                logger.info(
+                    f"Resuming from {done} of {total} ({pct}% done, "
+                    f"{len(prior)} segments) - transcribing the remainder..."
+                )
+            else:
+                logger.info(f"Resuming from {done} ({len(prior)} segments already done)...")
 
         def _on_segment(seg: dict) -> None:
             # Skip anything we already persisted (resume re-decode overlap).
@@ -205,6 +224,7 @@ class WhisperTranscriptionProvider:
                 str(temp_output),
                 verbose,
                 estimated_duration=self._estimated_duration,
+                audio_duration=self._audio_duration,
                 language=language,
                 offset_ms=resume_offset,
                 segment_callback=_on_segment,

--- a/src/pidcast/resume.py
+++ b/src/pidcast/resume.py
@@ -121,6 +121,11 @@ def resume_job(manifest: JobManifest) -> None:
         if OBSIDIAN_PATH:
             analysis_output_dir = Path(OBSIDIAN_PATH)
 
+    # Reuse the ORIGINAL recording's metadata (title, url, channel) so the resumed
+    # transcript keeps its real name and front matter - otherwise the title would
+    # be re-derived from the checkpoint's generic "source.wav" filename.
+    video_info_override = manifest.video_info_obj()
+
     run_uid = uuid.uuid4().hex[:12]
     run_timestamp = datetime.datetime.now().isoformat()
 
@@ -134,5 +139,6 @@ def resume_job(manifest: JobManifest) -> None:
             run_uid,
             run_timestamp,
             time.time(),
+            video_info_override=video_info_override,
         )
     )

--- a/src/pidcast/resume.py
+++ b/src/pidcast/resume.py
@@ -1,0 +1,129 @@
+"""Resume a paused/interrupted transcription job from its checkpoint manifest.
+
+Reconstructs the original CLI arguments from the manifest, validates that the job
+can actually be resumed (binary, model, audio present), points the input at the
+job dir's ``source.wav`` so nothing is re-downloaded, skips duplicate detection,
+and re-enters the normal workflow with the checkpoint wired in.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import time
+import uuid
+from pathlib import Path
+
+from .checkpoint import DONE, JobManifest
+from .config import DEFAULT_STATS_FILE, WHISPER_CPP_PATH
+from .utils import log_error, log_section
+
+logger = logging.getLogger(__name__)
+
+
+def _reconstruct_args(manifest: JobManifest):
+    """Rebuild an argparse.Namespace: full defaults overlaid with persisted flags."""
+    # Parse with a throwaway input to populate every default, then overlay.
+    import sys
+
+    from .cli import parse_arguments
+
+    saved_argv = sys.argv
+    try:
+        sys.argv = ["pidcast", manifest.source_wav_path.as_posix()]
+        args = parse_arguments()
+    finally:
+        sys.argv = saved_argv
+
+    for key, value in manifest.cli_args.items():
+        setattr(args, key, value)
+
+    # Resume always points at the job-dir source WAV (a local file), forces past
+    # duplicate detection, and disables test-segment.
+    args.input_source = str(manifest.source_wav_path)
+    args.force = True
+    args.test_segment = None
+    args.start_at = None
+    args.analyze_existing = None
+    args.diarize_existing = None
+    args.resume_job_id = manifest.job_id
+    args.no_checkpoint = False
+    # Keep the checkpoint across a resume that itself gets paused again.
+    args.keep_checkpoint = getattr(args, "keep_checkpoint", False)
+    return args
+
+
+def _preflight(manifest: JobManifest) -> bool:
+    """Validate the job can be resumed; log and return False if not."""
+    if not manifest.source_wav_path.exists():
+        log_error(
+            f"Checkpoint audio missing: {manifest.source_wav_path}\n"
+            "  Cannot resume without the source WAV. Re-run the original command."
+        )
+        return False
+    if manifest.provider == "whisper" and not WHISPER_CPP_PATH:
+        log_error("WHISPER_CPP_PATH is not set - cannot resume a whisper job.")
+        return False
+    # Resolve the model by name (paths may have moved since the job was created).
+    if manifest.provider == "whisper":
+        from .transcription import resolve_whisper_model
+
+        model_name = manifest.cli_args.get("whisper_model") or manifest.model
+        try:
+            resolve_whisper_model(model_name)
+        except Exception as e:
+            log_error(f"Cannot resolve whisper model '{model_name}' for resume: {e}")
+            return False
+    return True
+
+
+def resume_job(manifest: JobManifest) -> None:
+    """Resume the given job to completion."""
+    phase = "diarization" if manifest.transcription.status == DONE else "transcription"
+    title = (manifest.video_info or {}).get("title", manifest.input_source)
+    log_section(f"Resuming {phase}: {title}")
+    logger.info(
+        f"Job {manifest.job_id} - {manifest.transcription.segment_count} segments done, "
+        f"resuming from {manifest.resume_offset_ms() // 1000}s"
+    )
+
+    if not _preflight(manifest):
+        return
+
+    args = _reconstruct_args(manifest)
+
+    # Resolve the whisper model name -> path now (workflow expects a resolved path).
+    if manifest.provider == "whisper":
+        from .transcription import resolve_whisper_model
+
+        args.whisper_model = resolve_whisper_model(
+            manifest.cli_args.get("whisper_model") or manifest.model
+        )
+
+    from .cli import _run_with_pause_handler
+    from .workflow import process_input_source
+
+    output_dir = Path(args.output_dir) if getattr(args, "output_dir", None) else Path.cwd()
+    stats_file = Path(args.stats_file) if getattr(args, "stats_file", None) else DEFAULT_STATS_FILE
+    analysis_output_dir = output_dir
+    if getattr(args, "save_to_obsidian", False):
+        from .config import OBSIDIAN_PATH
+
+        if OBSIDIAN_PATH:
+            analysis_output_dir = Path(OBSIDIAN_PATH)
+
+    run_uid = uuid.uuid4().hex[:12]
+    run_timestamp = datetime.datetime.now().isoformat()
+
+    _run_with_pause_handler(
+        lambda: process_input_source(
+            args.input_source,
+            args,
+            output_dir,
+            analysis_output_dir,
+            stats_file,
+            run_uid,
+            run_timestamp,
+            time.time(),
+        )
+    )

--- a/src/pidcast/resume.py
+++ b/src/pidcast/resume.py
@@ -82,10 +82,19 @@ def resume_job(manifest: JobManifest) -> None:
     phase = "diarization" if manifest.transcription.status == DONE else "transcription"
     title = (manifest.video_info or {}).get("title", manifest.input_source)
     log_section(f"Resuming {phase}: {title}")
-    logger.info(
-        f"Job {manifest.job_id} - {manifest.transcription.segment_count} segments done, "
-        f"resuming from {manifest.resume_offset_ms() // 1000}s"
-    )
+    if phase == "diarization":
+        logger.info(
+            f"Job {manifest.job_id} - transcription already complete, "
+            "resuming at the diarization step."
+        )
+    else:
+        from .providers.whisper_provider import _fmt_clock
+
+        offset_ms = manifest.resume_offset_ms()
+        logger.info(
+            f"Job {manifest.job_id} - {manifest.transcription.segment_count} segments done, "
+            f"continuing from {_fmt_clock(offset_ms)}."
+        )
 
     if not _preflight(manifest):
         return

--- a/src/pidcast/transcription.py
+++ b/src/pidcast/transcription.py
@@ -496,6 +496,7 @@ def _run_whisper_streaming(
     verbose: bool,
     show_progress: bool,
     estimated_duration: float | None,
+    audio_duration: float | None,
     offset_ms: int | None,
     segment_callback: Callable[[dict], None] | None,
     pause_check: Callable[[], bool] | None,
@@ -515,10 +516,22 @@ def _run_whisper_streaming(
         TranscriptionPaused: if ``pause_check`` returns True mid-run.
         subprocess.CalledProcessError: on non-zero exit.
     """
+    offset_base = int(offset_ms or 0)
+
+    # Progress is driven by AUDIO POSITION (segment end-time vs total audio
+    # duration), not wall-clock, so it stays correct when resuming from an offset:
+    # the bar starts at offset/duration and Rich derives the ETA from throughput.
+    # Fall back to the wall-clock estimate only when the true duration is unknown.
+    total = None
+    if audio_duration and audio_duration > 0:
+        total = int(audio_duration * 1000)  # ms scale (audio timeline)
+    elif estimated_duration and estimated_duration > 0:
+        total = int(estimated_duration * 1000)
+
+    label = "Resuming transcription" if offset_base > 0 else "Transcribing"
     progress_ctx = None
     progress = None
     task = None
-    total = None
     if show_progress and not verbose:
         try:
             from rich.progress import (
@@ -527,20 +540,22 @@ def _run_whisper_streaming(
                 SpinnerColumn,
                 TextColumn,
                 TimeElapsedColumn,
+                TimeRemainingColumn,
             )
 
             progress = Progress(
                 SpinnerColumn(),
-                TextColumn("[cyan]Transcribing..."),
+                TextColumn(f"[cyan]{label}..."),
                 BarColumn(),
                 TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+                TextColumn("[dim]elapsed[/dim]"),
                 TimeElapsedColumn(),
+                TextColumn("[dim]eta[/dim]"),
+                TimeRemainingColumn(),
             )
             progress_ctx = progress
-            if estimated_duration and estimated_duration > 0:
-                total = int(estimated_duration * 1000)  # ms scale
         except ImportError:
-            logger.info("Transcribing (install 'rich' for progress display)...")
+            logger.info(f"{label} (install 'rich' for progress display)...")
 
     # Verbose: inherit stdout so whisper prints directly; only poll for pause.
     stdout_target = None if verbose else subprocess.PIPE
@@ -551,8 +566,6 @@ def _run_whisper_streaming(
         text=True,
         bufsize=1,
     )
-
-    offset_base = int(offset_ms or 0)
 
     def _terminate_for_pause() -> None:
         proc.terminate()
@@ -567,6 +580,10 @@ def _run_whisper_streaming(
         if progress_ctx is not None:
             progress_ctx.start()
             task = progress.add_task("transcribe", total=total)
+            # Seed the bar at the resume offset so % and ETA are right from the
+            # first new segment (a resumed run starts partway through the audio).
+            if total and offset_base > 0:
+                progress.update(task, completed=min(offset_base, total - 1))
 
         if proc.stdout is not None:
             for line in proc.stdout:
@@ -624,6 +641,7 @@ def run_whisper_transcription(
     temperature: float | None = None,
     no_fallback: bool = False,
     suppress_nst: bool = False,
+    audio_duration: float | None = None,
     offset_ms: int | None = None,
     segment_callback: "Callable[[dict], None] | None" = None,
     pause_check: "Callable[[], bool] | None" = None,
@@ -725,6 +743,7 @@ def run_whisper_transcription(
             verbose=verbose,
             show_progress=show_progress,
             estimated_duration=estimated_duration,
+            audio_duration=audio_duration,
             offset_ms=offset_ms,
             segment_callback=segment_callback,
             pause_check=pause_check,

--- a/src/pidcast/transcription.py
+++ b/src/pidcast/transcription.py
@@ -1,8 +1,11 @@
 """Whisper transcription functionality."""
 
+import contextlib
 import logging
+import re
 import subprocess
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 from .config import (
@@ -15,8 +18,85 @@ from .config import (
     WHISPER_MODELS_DIR,
     WHISPER_VAD_MODEL,
 )
-from .exceptions import TranscriptionError
+from .exceptions import TranscriptionError, TranscriptionPaused
 from .utils import load_json_file
+
+# whisper.cpp stdout segment line: "[HH:MM:SS.mmm --> HH:MM:SS.mmm]   text".
+# Tolerant of '.' or ',' as the ms separator (varies by build) and inner spacing.
+_SEGMENT_LINE_RE = re.compile(
+    r"^\s*\[(\d{2}):(\d{2}):(\d{2})[.,](\d{3})\s*-->\s*"
+    r"(\d{2}):(\d{2}):(\d{2})[.,](\d{3})\]\s*(.*)$"
+)
+
+
+def _ts_to_ms(h: str, m: str, s: str, ms: str) -> int:
+    return ((int(h) * 60 + int(m)) * 60 + int(s)) * 1000 + int(ms)
+
+
+def parse_whisper_segment_line(line: str) -> dict | None:
+    """Parse one whisper stdout segment line into ``{from_ms, to_ms, text}``.
+
+    Returns None for lines that are not segment lines (progress, banners, blank).
+    A line that *looks* like a segment (starts with ``[``) but fails to parse is
+    logged at WARNING so a format drift is caught rather than silently dropped.
+    """
+    match = _SEGMENT_LINE_RE.match(line)
+    if not match:
+        if line.lstrip().startswith("[") and "-->" in line:
+            logger.warning("Unparseable whisper segment line (format drift?): %r", line.strip())
+        return None
+    g = match.groups()
+    return {
+        "from_ms": _ts_to_ms(g[0], g[1], g[2], g[3]),
+        "to_ms": _ts_to_ms(g[4], g[5], g[6], g[7]),
+        "text": g[8].strip(),
+    }
+
+
+def ms_to_timestamp(ms: int) -> str:
+    """Render absolute milliseconds as a whisper-style ``HH:MM:SS,mmm`` string."""
+    ms = max(0, int(ms))
+    hours, rem = divmod(ms, 3_600_000)
+    minutes, rem = divmod(rem, 60_000)
+    seconds, millis = divmod(rem, 1000)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d},{millis:03d}"
+
+
+def merge_segments_to_whisper_json(
+    segments: list[dict],
+    base_template: dict | None = None,
+) -> dict:
+    """Assemble a whisper-shaped JSON dict from streamed ``{from_ms,to_ms,text}`` records.
+
+    Each ``transcription[]`` entry carries the ``offsets`` sub-dict (ms ints) that
+    :func:`pidcast.diarization.merge_whisper_with_diarization` and the plain-text
+    fallback both read, plus regenerated ``timestamps`` strings so the saved file
+    is internally consistent. Segments are de-overlapped (a re-decoded segment from
+    a VAD-backed-off resume whose start precedes the previous segment's end is
+    dropped) and then run through :func:`dedupe_whisper_segments`.
+    """
+    deoverlapped: list[dict] = []
+    last_to = -1
+    for seg in sorted(segments, key=lambda s: int(s.get("from_ms", 0))):
+        from_ms = int(seg.get("from_ms", 0))
+        to_ms = int(seg.get("to_ms", from_ms))
+        # Drop a segment fully inside what we already have (resume re-decode overlap).
+        if to_ms <= last_to:
+            continue
+        deoverlapped.append(
+            {
+                "text": seg.get("text", ""),
+                "offsets": {"from": from_ms, "to": to_ms},
+                "timestamps": {"from": ms_to_timestamp(from_ms), "to": ms_to_timestamp(to_ms)},
+            }
+        )
+        last_to = to_ms
+
+    transcription = dedupe_whisper_segments(deoverlapped)
+    result = dict(base_template) if base_template else {}
+    result["transcription"] = transcription
+    return result
+
 
 logger = logging.getLogger(__name__)
 
@@ -410,6 +490,123 @@ def extract_audio_segment(
 # ============================================================================
 
 
+def _run_whisper_streaming(
+    command: list[str],
+    *,
+    verbose: bool,
+    show_progress: bool,
+    estimated_duration: float | None,
+    offset_ms: int | None,
+    segment_callback: Callable[[dict], None] | None,
+    pause_check: Callable[[], bool] | None,
+) -> None:
+    """Run whisper as a single Popen, reading stdout line-by-line.
+
+    Unifies every non-verbose path (estimate / no-estimate / no-rich) onto one
+    streaming loop so the segment callback and pause check work regardless of
+    whether a duration estimate is available. whisper.cpp prints each completed
+    segment to stdout and flushes, so we parse those lines live.
+
+    In verbose mode stdout is inherited (whisper prints directly) so we cannot
+    parse segments - pause still works via process polling, but per-segment
+    checkpointing does not. Callers needing checkpointing run non-verbose.
+
+    Raises:
+        TranscriptionPaused: if ``pause_check`` returns True mid-run.
+        subprocess.CalledProcessError: on non-zero exit.
+    """
+    progress_ctx = None
+    progress = None
+    task = None
+    total = None
+    if show_progress and not verbose:
+        try:
+            from rich.progress import (
+                BarColumn,
+                Progress,
+                SpinnerColumn,
+                TextColumn,
+                TimeElapsedColumn,
+            )
+
+            progress = Progress(
+                SpinnerColumn(),
+                TextColumn("[cyan]Transcribing..."),
+                BarColumn(),
+                TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+                TimeElapsedColumn(),
+            )
+            progress_ctx = progress
+            if estimated_duration and estimated_duration > 0:
+                total = int(estimated_duration * 1000)  # ms scale
+        except ImportError:
+            logger.info("Transcribing (install 'rich' for progress display)...")
+
+    # Verbose: inherit stdout so whisper prints directly; only poll for pause.
+    stdout_target = None if verbose else subprocess.PIPE
+    proc = subprocess.Popen(
+        command,
+        stdout=stdout_target,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+
+    offset_base = int(offset_ms or 0)
+
+    def _terminate_for_pause() -> None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+    last_to_ms = offset_base
+    try:
+        if progress_ctx is not None:
+            progress_ctx.start()
+            task = progress.add_task("transcribe", total=total)
+
+        if proc.stdout is not None:
+            for line in proc.stdout:
+                if pause_check is not None and pause_check():
+                    _terminate_for_pause()
+                    raise TranscriptionPaused(last_offset_ms=last_to_ms)
+
+                seg = parse_whisper_segment_line(line)
+                if seg is None:
+                    continue
+                last_to_ms = seg["to_ms"]
+                if segment_callback is not None:
+                    segment_callback(seg)
+                if progress is not None and task is not None and total:
+                    progress.update(task, completed=min(seg["to_ms"], total - 1))
+        else:
+            # Verbose path: no stdout to read; poll for pause.
+            while proc.poll() is None:
+                if pause_check is not None and pause_check():
+                    _terminate_for_pause()
+                    raise TranscriptionPaused(last_offset_ms=last_to_ms)
+                time.sleep(0.2)
+
+        proc.wait()
+        if progress is not None and task is not None and total:
+            progress.update(task, completed=total)
+
+        if proc.returncode != 0:
+            stderr = proc.stderr.read() if proc.stderr else ""
+            raise subprocess.CalledProcessError(proc.returncode, command, stderr=stderr)
+    finally:
+        if progress_ctx is not None:
+            progress_ctx.stop()
+        if proc.stdout is not None:
+            proc.stdout.close()
+        if proc.stderr is not None and not proc.stderr.closed:
+            with contextlib.suppress(Exception):
+                proc.stderr.close()
+
+
 def run_whisper_transcription(
     audio_file: str | Path,
     whisper_model: str,
@@ -427,6 +624,9 @@ def run_whisper_transcription(
     temperature: float | None = None,
     no_fallback: bool = False,
     suppress_nst: bool = False,
+    offset_ms: int | None = None,
+    segment_callback: "Callable[[dict], None] | None" = None,
+    pause_check: "Callable[[], bool] | None" = None,
 ) -> bool:
     """Run whisper transcription.
 
@@ -452,6 +652,14 @@ def run_whisper_transcription(
         no_fallback: Disable temperature fallback while decoding (whisper -nf).
         suppress_nst: Suppress non-speech tokens (whisper -sns). Reduces boilerplate
             hallucinations on low-speech audio.
+        offset_ms: Resume offset in milliseconds (whisper -ot). Decoding starts here;
+            emitted timestamps remain absolute (relative to file start).
+        segment_callback: Invoked once per completed segment as it streams off
+            whisper's stdout, with ``{"from_ms", "to_ms", "text"}`` (absolute ms).
+            Enables live checkpointing for pause/resume.
+        pause_check: Polled between stdout lines; if it returns True the whisper
+            subprocess is terminated cleanly and the function raises
+            :class:`TranscriptionPaused` (already-streamed segments are preserved).
 
     Returns:
         True if successful
@@ -488,6 +696,12 @@ def run_whisper_transcription(
         if vad_threshold is not None:
             command.extend(["-vt", str(vad_threshold)])
 
+    # Resume: start decoding at a time offset. whisper.cpp emits ABSOLUTE
+    # timestamps under -ot (verified), so the streamed segments need no
+    # offset-correction - they align directly onto the pre-pause segments.
+    if offset_ms and offset_ms > 0:
+        command.extend(["-ot", str(int(offset_ms))])
+
     # Add output format flag
     format_flags = {
         "txt": "--output-txt",
@@ -506,75 +720,15 @@ def run_whisper_transcription(
         logger.info(f"Running Whisper command: {' '.join(command)}")
 
     try:
-        # Run transcription with Rich progress bar
-        if show_progress and not verbose:
-            try:
-                from rich.progress import (
-                    BarColumn,
-                    Progress,
-                    SpinnerColumn,
-                    TextColumn,
-                    TimeElapsedColumn,
-                )
-
-                with Progress(
-                    SpinnerColumn(),
-                    TextColumn("[cyan]Transcribing..."),
-                    BarColumn(),
-                    TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-                    TimeElapsedColumn(),
-                ) as progress:
-                    # Add task with total based on estimated duration
-                    if estimated_duration and estimated_duration > 0:
-                        # Use estimated duration in deciseconds for granular updates
-                        total = int(estimated_duration * 10)
-                        task = progress.add_task("transcribe", total=total)
-
-                        # Run transcription in subprocess
-                        proc = subprocess.Popen(
-                            command, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
-                        )
-
-                        # Update progress based on elapsed time
-                        start_time = time.time()
-                        while proc.poll() is None:
-                            elapsed = time.time() - start_time
-                            completed = min(int(elapsed * 10), total - 1)  # Cap at 99%
-                            progress.update(task, completed=completed)
-                            time.sleep(0.1)
-
-                        # Mark as complete
-                        progress.update(task, completed=total)
-
-                        # Check return code
-                        if proc.returncode != 0:
-                            stderr = proc.stderr.read().decode() if proc.stderr else ""
-                            raise subprocess.CalledProcessError(
-                                proc.returncode, command, stderr=stderr
-                            )
-
-                    else:
-                        # No estimate - just show spinner
-                        task = progress.add_task("transcribe", total=None)
-                        subprocess.run(
-                            command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
-                        )
-                        progress.update(task, completed=1)
-
-            except ImportError:
-                # Fallback if rich is not installed
-                logger.info("Transcribing (install 'rich' for progress display)...")
-                subprocess.run(
-                    command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
-                )
-        else:
-            # Verbose mode or no progress
-            if verbose:
-                subprocess.run(command, check=True)
-            else:
-                subprocess.run(
-                    command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
-                )
+        _run_whisper_streaming(
+            command,
+            verbose=verbose,
+            show_progress=show_progress,
+            estimated_duration=estimated_duration,
+            offset_ms=offset_ms,
+            segment_callback=segment_callback,
+            pause_check=pause_check,
+        )
 
         if verbose:
             logger.info("✓ Transcription completed successfully.")

--- a/src/pidcast/workflow.py
+++ b/src/pidcast/workflow.py
@@ -122,6 +122,7 @@ def _ensure_job_manifest(
     model_name: str | None,
     vad_model: str | None,
     diarize: bool,
+    output_dir: Path,
 ):
     """Create (or load, when resuming) the checkpoint manifest for this run.
 
@@ -161,6 +162,10 @@ def _ensure_job_manifest(
     job_id = compute_job_id(
         audio_sig, provider, model_name or "", getattr(args, "language", None), vad_signature
     )
+    persisted_args = _persistable_args(args)
+    # Pin the RESOLVED output dir so resume writes to the original location, not the
+    # cwd it happens to be launched from (args.output_dir is None for a cwd default).
+    persisted_args["output_dir"] = str(output_dir)
     manifest = JobManifest(
         job_id=job_id,
         input_source=input_source,
@@ -170,7 +175,7 @@ def _ensure_job_manifest(
         model=model_name or "",
         language=getattr(args, "language", None),
         vad_signature=vad_signature,
-        cli_args=_persistable_args(args),
+        cli_args=persisted_args,
         video_info=video_info.to_dict() if video_info else None,
     )
     manifest.diarization.requested = diarize
@@ -932,6 +937,10 @@ def process_input_source(
                 video_info.channel = video_info_override.channel
             if video_info_override.upload_date:
                 video_info.upload_date = video_info_override.upload_date
+            # Preserve the original source url (resume): otherwise the front matter
+            # would point at the checkpoint's source.wav, breaking --diarize-existing.
+            if video_info_override.webpage_url:
+                video_info.webpage_url = video_info_override.webpage_url
 
         logger.info(f"Title: {video_info.title}")
 
@@ -1060,6 +1069,7 @@ def process_input_source(
                     whisper_model_name,
                     vad_model,
                     diarize,
+                    output_dir,
                 )
 
             logger.info("\nTranscribing audio with Whisper...")

--- a/src/pidcast/workflow.py
+++ b/src/pidcast/workflow.py
@@ -1072,6 +1072,7 @@ def process_input_source(
                 whisper_options=whisper_opts,
                 checkpoint=job_manifest,
                 pause_check=_pause_requested_check if job_manifest is not None else None,
+                audio_duration=audio_duration if audio_duration and audio_duration > 0 else None,
             )
 
         transcription_result = transcription_provider.transcribe(

--- a/src/pidcast/workflow.py
+++ b/src/pidcast/workflow.py
@@ -29,6 +29,7 @@ from .exceptions import (
     DownloadError,
     FileProcessingError,
     TranscriptionError,
+    TranscriptionPaused,
 )
 from .markdown import create_analysis_markdown_file, create_markdown_file
 from .transcription import (
@@ -51,6 +52,56 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 
+# Set by the SIGINT handler (cli.py) to request a clean pause of the running
+# transcription. The whisper stream loop polls this between segments.
+_pause_requested = False
+
+
+def request_pause() -> None:
+    """Signal the running transcription to pause at the next segment boundary."""
+    global _pause_requested
+    _pause_requested = True
+
+
+def reset_pause() -> None:
+    global _pause_requested
+    _pause_requested = False
+
+
+def _pause_requested_check() -> bool:
+    return _pause_requested
+
+
+# Flags that are NOT persisted into the resume manifest (they are run-local,
+# resolved at runtime, or would prevent a clean resume).
+_NON_RESUMABLE_ARG_KEYS = {
+    "resume",
+    "no_checkpoint",
+    "keep_checkpoint",
+    "test_segment",
+    "start_at",
+    "analyze_existing",
+    "diarize_existing",
+    "verbose",
+}
+
+
+def _persistable_args(args: argparse.Namespace) -> dict[str, Any]:
+    """The subset of args needed to re-run a job on `pidcast resume`.
+
+    Stores the whisper model NAME via the original ``args.whisper_model`` value as
+    given by the user (resume re-resolves it), and drops run-local flags. Only
+    JSON-serializable scalars/lists are kept.
+    """
+    out: dict[str, Any] = {}
+    for key, value in vars(args).items():
+        if key in _NON_RESUMABLE_ARG_KEYS:
+            continue
+        if value is None or isinstance(value, (str, int, float, bool, list)):
+            out[key] = value
+    return out
+
+
 def _extract_whisper_model_name(model_path: str | None) -> str | None:
     """Extract clean model name from whisper model path.
 
@@ -59,6 +110,76 @@ def _extract_whisper_model_name(model_path: str | None) -> str | None:
     if not model_path:
         return None
     return Path(model_path).stem.removeprefix("ggml-")
+
+
+def _ensure_job_manifest(
+    args: argparse.Namespace,
+    input_source: str,
+    audio_file: str,
+    smart_filename: str,
+    video_info: VideoInfo,
+    provider: str,
+    model_name: str | None,
+    vad_model: str | None,
+    diarize: bool,
+):
+    """Create (or load, when resuming) the checkpoint manifest for this run.
+
+    Copies the working WAV into the job dir as ``source.wav`` BEFORE transcription
+    so a pause/crash is resumable without re-downloading or re-converting.
+    """
+    from .checkpoint import (
+        IN_PROGRESS,
+        JobManifest,
+        compute_job_id,
+        quick_file_signature,
+    )
+
+    resume_job_id = getattr(args, "resume_job_id", None)
+    if resume_job_id:
+        existing = JobManifest.load(
+            (
+                JobManifest(
+                    job_id=resume_job_id,
+                    input_source="",
+                    audio_signature="",
+                    smart_filename="",
+                    provider="",
+                    model="",
+                    language=None,
+                    vad_signature="",
+                )
+            ).job_dir
+        )
+        if existing is not None:
+            existing.transcription.status = IN_PROGRESS
+            existing.save()
+            return existing
+
+    vad_signature = f"vad:{Path(vad_model).name}" if vad_model else "novad"
+    audio_sig = quick_file_signature(audio_file)
+    job_id = compute_job_id(
+        audio_sig, provider, model_name or "", getattr(args, "language", None), vad_signature
+    )
+    manifest = JobManifest(
+        job_id=job_id,
+        input_source=input_source,
+        audio_signature=audio_sig,
+        smart_filename=smart_filename,
+        provider=provider,
+        model=model_name or "",
+        language=getattr(args, "language", None),
+        vad_signature=vad_signature,
+        cli_args=_persistable_args(args),
+        video_info=video_info.to_dict() if video_info else None,
+    )
+    manifest.diarization.requested = diarize
+    manifest.transcription.status = IN_PROGRESS
+    manifest.save()
+    # Copy the working audio into the job dir up-front (resume source of truth).
+    if not manifest.source_wav_path.exists():
+        shutil.copy2(audio_file, manifest.source_wav_path)
+    return manifest
 
 
 def parse_transcript_file(filepath: str, verbose: bool = False) -> tuple[str, VideoInfo]:
@@ -741,6 +862,9 @@ def process_input_source(
     smart_filename: str | None = None
     transcription_result = None
     success = False
+    paused = False
+    job_manifest = None
+    reset_pause()
 
     try:
         # Validate input
@@ -916,6 +1040,28 @@ def process_input_source(
                 "suppress_nst": getattr(args, "suppress_nst", True),
             }
 
+            # Set up the resume/pause checkpoint (whisper only). Disabled for
+            # test-segment runs and when --no-checkpoint is passed. The source WAV
+            # is copied into the job dir BEFORE transcription so a pause/crash is
+            # resumable even after the finally-block cleans the working audio.
+            checkpoint_enabled = (
+                test_segment is None
+                and not getattr(args, "no_checkpoint", False)
+                and not getattr(args, "resume_job_id", None)  # set below if resuming
+            )
+            if checkpoint_enabled or getattr(args, "resume_job_id", None):
+                job_manifest = _ensure_job_manifest(
+                    args,
+                    input_source,
+                    audio_file,
+                    smart_filename,
+                    video_info,
+                    transcription_provider_name,
+                    whisper_model_name,
+                    vad_model,
+                    diarize,
+                )
+
             logger.info("\nTranscribing audio with Whisper...")
             transcription_provider = WhisperTranscriptionProvider(
                 whisper_model=args.whisper_model,
@@ -924,6 +1070,8 @@ def process_input_source(
                 estimated_duration=estimated_time,
                 save_whisper_json_to=whisper_json_dest,
                 whisper_options=whisper_opts,
+                checkpoint=job_manifest,
+                pause_check=_pause_requested_check if job_manifest is not None else None,
             )
 
         transcription_result = transcription_provider.transcribe(
@@ -935,6 +1083,14 @@ def process_input_source(
 
         transcription_duration = transcription_result.duration
         speaker_count = transcription_result.speaker_count
+
+        # Transcription finished cleanly: mark it done in the manifest so a later
+        # crash (e.g. during diarization) resumes into diarization, not whisper.
+        if job_manifest is not None:
+            from .checkpoint import DONE
+
+            job_manifest.transcription.status = DONE
+            job_manifest.save()
 
         # Auto-save audio when diarizing (for diarization retry)
         saved_audio_path = None
@@ -1121,7 +1277,31 @@ def process_input_source(
                 shutil.copy2(audio_file, saved_audio)
             logger.info(f"Audio saved to: file://{saved_audio.absolute()}")
 
+        # Success: drop the checkpoint unless the user wants to keep it.
+        if job_manifest is not None and not getattr(args, "keep_checkpoint", False):
+            from .checkpoint import cleanup_job_dir
+
+            cleanup_job_dir(job_manifest.job_id)
+        elif job_manifest is not None:
+            logger.info(f"Checkpoint kept: {job_manifest.job_dir}")
+
         return True
+
+    except TranscriptionPaused as e:
+        paused = True
+        if job_manifest is not None:
+            from .checkpoint import PAUSED
+
+            job_manifest.transcription.status = PAUSED
+            job_manifest.save()
+            n = job_manifest.transcription.segment_count
+            mm, ss = divmod(int(e.last_offset_ms) // 1000, 60)
+            log_section("Transcription paused")
+            logger.info(f"Saved {n} segments (up to {mm:02d}:{ss:02d}).")
+            logger.info("Resume with:  pidcast resume")
+        else:
+            logger.info("\n\n✗ Transcription interrupted.")
+        return False
 
     except KeyboardInterrupt:
         logger.info("\n\n✗ Process interrupted by user.")
@@ -1179,8 +1359,15 @@ def process_input_source(
         return False
 
     finally:
-        # Clean up temporary audio files
-        if audio_file:
+        # Clean up temporary audio files. Never touch a job-dir source.wav: that is
+        # the resume source of truth and must survive a pause/crash, and on a resume
+        # run the working audio IS the job-dir copy.
+        in_job_dir = bool(
+            job_manifest is not None
+            and audio_file
+            and str(job_manifest.job_dir) in str(Path(audio_file).resolve())
+        )
+        if audio_file and not in_job_dir:
             if is_local_file:
                 audio_path = Path(audio_file)
                 if audio_path.exists() and "_16k.wav" in audio_file:
@@ -1194,8 +1381,8 @@ def process_input_source(
             else:
                 cleanup_temp_files(audio_file, args.verbose)
 
-        # Save failure statistics if needed
-        if not success and video_info:
+        # Save failure statistics if needed (a deliberate pause is not a failure).
+        if not success and not paused and video_info:
             end_time = time.time()
             duration = end_time - start_time
             stats = TranscriptionStats(

--- a/tests/test_checkpoint_resume.py
+++ b/tests/test_checkpoint_resume.py
@@ -239,6 +239,66 @@ def test_quick_file_signature_small_file_hashes_whole(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Resume arg/metadata reconstruction (regression: don't lose the original
+# title / output dir / source url when resuming from a different directory)
+# ---------------------------------------------------------------------------
+
+
+def test_reconstruct_args_restores_metadata_and_output_dir(checkpoint_dir, monkeypatch):
+    from pidcast.config import VideoInfo
+    from pidcast.resume import _reconstruct_args
+
+    m = _make_manifest()
+    m.video_info = VideoInfo(
+        title="Sabre Interview",
+        webpage_url="file:///recordings/sabre.wav",
+        channel="",
+        uploader="",
+        duration=600,
+        duration_string="10:00",
+        view_count=0,
+        upload_date="",
+        description="",
+    ).to_dict()
+    # Original run wrote to a specific dir; resume must restore it, not use cwd.
+    m.cli_args = {"output_dir": "/some/original/out", "whisper_model": "base.en", "force": False}
+    m.save()
+
+    args = _reconstruct_args(m)
+
+    # Input is redirected to the checkpoint's source.wav and duplicate detection is off.
+    assert args.input_source == str(m.source_wav_path)
+    assert args.force is True
+    assert args.resume_job_id == m.job_id
+    # The original output dir survives (so resume writes to the intended location).
+    assert args.output_dir == "/some/original/out"
+    # The persisted model name is carried through for re-resolution.
+    assert args.whisper_model == "base.en"
+
+
+def test_manifest_video_info_obj_round_trips():
+    from pidcast.config import VideoInfo
+
+    m = _make_manifest()
+    vi = VideoInfo(
+        title="Sabre Interview",
+        webpage_url="file:///recordings/sabre.wav",
+        channel="ACME",
+        uploader="ACME",
+        duration=600,
+        duration_string="10:00",
+        view_count=0,
+        upload_date="20260624",
+        description="desc",
+    )
+    m.video_info = vi.to_dict()
+    restored = m.video_info_obj()
+    assert restored.title == "Sabre Interview"
+    assert restored.webpage_url == "file:///recordings/sabre.wav"
+    assert restored.channel == "ACME"
+
+
+# ---------------------------------------------------------------------------
 # Streaming + pause loop (against a fake whisper binary)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_checkpoint_resume.py
+++ b/tests/test_checkpoint_resume.py
@@ -1,0 +1,316 @@
+"""Tests for transcription pause/resume checkpointing.
+
+Covers the load-bearing pieces: whisper stdout segment parsing, timestamp
+rendering, the de-overlapping merge across a resume seam, and the JobManifest
+JSONL/manifest round-trip plus resumable-job discovery.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import pidcast.checkpoint as cp
+from pidcast.transcription import (
+    merge_segments_to_whisper_json,
+    ms_to_timestamp,
+    parse_whisper_segment_line,
+)
+
+# ---------------------------------------------------------------------------
+# Segment line parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_segment_line_dot_separator():
+    seg = parse_whisper_segment_line("[00:00:05.000 --> 00:00:10.440]   Hello world.")
+    assert seg == {"from_ms": 5000, "to_ms": 10440, "text": "Hello world."}
+
+
+def test_parse_segment_line_comma_separator():
+    # Some whisper.cpp builds render ms with a comma.
+    seg = parse_whisper_segment_line("[00:01:02,500 --> 00:01:05,000]  hi")
+    assert seg == {"from_ms": 62500, "to_ms": 65000, "text": "hi"}
+
+
+def test_parse_segment_line_hours():
+    seg = parse_whisper_segment_line("[01:02:03.004 --> 01:02:04.005]  x")
+    assert seg["from_ms"] == ((1 * 60 + 2) * 60 + 3) * 1000 + 4
+
+
+def test_parse_non_segment_lines_return_none():
+    assert parse_whisper_segment_line("whisper_print_timings: load time = 5 ms") is None
+    assert parse_whisper_segment_line("") is None
+    assert parse_whisper_segment_line("processing 'audio.wav'") is None
+
+
+def test_parse_malformed_bracket_line_warns_and_returns_none(caplog):
+    # A line that looks like a segment but doesn't parse must not be silently dropped.
+    with caplog.at_level("WARNING"):
+        assert parse_whisper_segment_line("[bad --> line] text") is None
+    assert any("format drift" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Timestamp rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ms,expected",
+    [
+        (0, "00:00:00,000"),
+        (5000, "00:00:05,000"),
+        (3661500, "01:01:01,500"),
+        (-10, "00:00:00,000"),  # clamps negatives
+    ],
+)
+def test_ms_to_timestamp(ms, expected):
+    assert ms_to_timestamp(ms) == expected
+
+
+# ---------------------------------------------------------------------------
+# Merge / de-overlap across the resume seam
+# ---------------------------------------------------------------------------
+
+
+def test_merge_produces_offsets_dict_schema():
+    # Diarization reads seg["offsets"]["from"]; the schema must carry it.
+    merged = merge_segments_to_whisper_json([{"from_ms": 0, "to_ms": 5000, "text": "a"}])
+    seg = merged["transcription"][0]
+    assert seg["offsets"] == {"from": 0, "to": 5000}
+    assert seg["timestamps"] == {"from": "00:00:00,000", "to": "00:00:05,000"}
+    assert seg["text"] == "a"
+
+
+def test_merge_preserves_base_template_metadata():
+    merged = merge_segments_to_whisper_json(
+        [{"from_ms": 0, "to_ms": 1000, "text": "a"}],
+        base_template={"model": {"type": "base"}, "systeminfo": "x"},
+    )
+    assert merged["model"] == {"type": "base"}
+    assert merged["systeminfo"] == "x"
+
+
+def test_merge_de_overlaps_resume_seam():
+    # Simulate a VAD-backed-off resume: the second invocation re-decodes a segment
+    # that ends inside the already-persisted prefix. It must be dropped.
+    segments = [
+        {"from_ms": 0, "to_ms": 5000, "text": "first"},
+        {"from_ms": 5000, "to_ms": 10000, "text": "second"},
+        # re-decoded overlap (ends at/inside 10000) -> dropped
+        {"from_ms": 8000, "to_ms": 10000, "text": "second-redecode"},
+        {"from_ms": 10000, "to_ms": 15000, "text": "third"},
+    ]
+    merged = merge_segments_to_whisper_json(segments)
+    texts = [s["text"] for s in merged["transcription"]]
+    assert texts == ["first", "second", "third"]
+
+
+def test_merge_offsets_monotonic_non_decreasing():
+    segments = [
+        {"from_ms": 10000, "to_ms": 15000, "text": "c"},
+        {"from_ms": 0, "to_ms": 5000, "text": "a"},
+        {"from_ms": 5000, "to_ms": 10000, "text": "b"},
+    ]
+    merged = merge_segments_to_whisper_json(segments)
+    offs = [s["offsets"]["from"] for s in merged["transcription"]]
+    assert offs == sorted(offs)
+
+
+# ---------------------------------------------------------------------------
+# JobManifest round-trip and discovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def checkpoint_dir(tmp_path, monkeypatch):
+    """Point CHECKPOINT_DIR at a temp dir for the duration of a test."""
+    d = tmp_path / "checkpoints"
+    monkeypatch.setattr(cp, "CHECKPOINT_DIR", d)
+    return d
+
+
+def _make_manifest(job_id="abc123def456"):
+    return cp.JobManifest(
+        job_id=job_id,
+        input_source="interview.wav",
+        audio_signature="sig",
+        smart_filename="2026-06-24_Interview",
+        provider="whisper",
+        model="large-v3",
+        language="en",
+        vad_signature="novad",
+    )
+
+
+def test_manifest_save_load_round_trip(checkpoint_dir):
+    m = _make_manifest()
+    m.transcription.status = cp.PAUSED
+    m.transcription.segment_count = 3
+    m.save()
+
+    loaded = cp.JobManifest.load(m.job_dir)
+    assert loaded is not None
+    assert loaded.job_id == m.job_id
+    assert loaded.transcription.status == cp.PAUSED
+    assert loaded.transcription.segment_count == 3
+    assert loaded.smart_filename == "2026-06-24_Interview"
+
+
+def test_segments_append_and_resume_offset(checkpoint_dir):
+    m = _make_manifest()
+    m.append_segment({"from_ms": 0, "to_ms": 5000, "text": "a"})
+    m.append_segment({"from_ms": 5000, "to_ms": 9000, "text": "b"})
+    assert m.resume_offset_ms() == 9000
+    assert len(m.load_segments()) == 2
+
+
+def test_load_segments_tolerates_partial_trailing_line(checkpoint_dir):
+    m = _make_manifest()
+    m.append_segment({"from_ms": 0, "to_ms": 5000, "text": "a"})
+    # Simulate a kill mid-write: append a partial JSON line by hand.
+    with open(m.segments_path, "a", encoding="utf-8") as f:
+        f.write('{"from_ms": 5000, "to_ms": 90')
+    segs = m.load_segments()
+    assert len(segs) == 1
+    assert segs[0]["text"] == "a"
+    assert m.resume_offset_ms() == 5000
+
+
+def test_find_resumable_jobs_lists_paused_and_partial(checkpoint_dir):
+    paused = _make_manifest("paused0000000001")
+    paused.transcription.status = cp.PAUSED
+    paused.save()
+
+    diar_pending = _make_manifest("diarpend00000002")
+    diar_pending.transcription.status = cp.DONE
+    diar_pending.diarization.status = cp.PENDING
+    diar_pending.save()
+
+    done = _make_manifest("alldone000000003")
+    done.transcription.status = cp.DONE
+    done.diarization.status = cp.DONE
+    done.save()
+
+    ids = {j.job_id for j in cp.find_resumable_jobs()}
+    assert "paused0000000001" in ids
+    assert "diarpend00000002" in ids
+    assert "alldone000000003" not in ids  # fully done -> not resumable
+
+
+def test_find_resumable_jobs_skips_corrupt_manifest(checkpoint_dir):
+    good = _make_manifest("good000000000001")
+    good.transcription.status = cp.PAUSED
+    good.save()
+
+    bad_dir = checkpoint_dir / "corrupt000000000"
+    bad_dir.mkdir(parents=True)
+    (bad_dir / "manifest.json").write_text("{not valid json", encoding="utf-8")
+
+    ids = {j.job_id for j in cp.find_resumable_jobs()}
+    assert ids == {"good000000000001"}
+
+
+def test_cleanup_job_dir_removes_everything(checkpoint_dir):
+    m = _make_manifest()
+    m.append_segment({"from_ms": 0, "to_ms": 1000, "text": "a"})
+    m.save()
+    assert m.job_dir.exists()
+    cp.cleanup_job_dir(m.job_id)
+    assert not m.job_dir.exists()
+
+
+def test_compute_job_id_changes_with_config():
+    base = cp.compute_job_id("sig", "whisper", "large-v3", "en", "novad")
+    assert base == cp.compute_job_id("sig", "whisper", "large-v3", "en", "novad")
+    # A different model or VAD signature yields a different job id.
+    assert base != cp.compute_job_id("sig", "whisper", "medium", "en", "novad")
+    assert base != cp.compute_job_id("sig", "whisper", "large-v3", "en", "vad:silero")
+
+
+def test_quick_file_signature_small_file_hashes_whole(tmp_path):
+    f = tmp_path / "small.wav"
+    f.write_bytes(b"hello world" * 10)
+    sig1 = cp.quick_file_signature(f)
+    # Same content -> same signature; changed content -> different.
+    assert sig1 == cp.quick_file_signature(f)
+    f.write_bytes(b"different content")
+    assert sig1 != cp.quick_file_signature(f)
+
+
+# ---------------------------------------------------------------------------
+# Streaming + pause loop (against a fake whisper binary)
+# ---------------------------------------------------------------------------
+
+_FAKE_WHISPER = """#!/bin/bash
+of=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -of) of="$2"; shift 2;;
+    *) shift;;
+  esac
+done
+for i in 0 1 2 3 4 5 6 7 8 9; do
+  start=$(printf "00:00:%02d.000" $((i*2)))
+  end=$(printf "00:00:%02d.000" $(((i+1)*2)))
+  echo "[$start --> $end]   segment $i"
+  sleep 0.1
+done
+echo '{"transcription":[]}' > "${of}.json"
+"""
+
+
+@pytest.fixture
+def fake_whisper(tmp_path, monkeypatch):
+    import pidcast.transcription as t
+
+    binp = tmp_path / "fake_whisper.sh"
+    binp.write_text(_FAKE_WHISPER)
+    binp.chmod(0o755)
+    monkeypatch.setattr(t, "WHISPER_CPP_PATH", str(binp))
+    return t
+
+
+def test_streaming_invokes_segment_callback(fake_whisper):
+    collected = []
+    fake_whisper.run_whisper_transcription(
+        "dummy.wav",
+        "m",
+        "json",
+        "/tmp/fake_stream_out",
+        verbose=False,
+        show_progress=False,
+        segment_callback=collected.append,
+    )
+    assert len(collected) == 10
+    assert collected[0] == {"from_ms": 0, "to_ms": 2000, "text": "segment 0"}
+
+
+def test_streaming_pause_raises_with_offset(fake_whisper):
+    from pidcast.exceptions import TranscriptionPaused
+
+    collected = []
+    pause_flag = {"v": False}
+
+    # Deterministic (no wall-clock race): request the pause from the callback once
+    # the 3rd segment lands. The next pause_check poll then trips it.
+    def cb(seg):
+        collected.append(seg)
+        if len(collected) == 3:
+            pause_flag["v"] = True
+
+    with pytest.raises(TranscriptionPaused) as exc:
+        fake_whisper.run_whisper_transcription(
+            "dummy.wav",
+            "m",
+            "json",
+            "/tmp/fake_pause_out",
+            verbose=False,
+            show_progress=False,
+            segment_callback=cb,
+            pause_check=lambda: pause_flag["v"],
+        )
+
+    # Paused partway: at least the 3 we saw, fewer than all 10, offset matches last.
+    assert 3 <= len(collected) < 10
+    assert exc.value.last_offset_ms == collected[-1]["to_ms"]


### PR DESCRIPTION
## What & why

Long local transcriptions are expensive on this Intel Mac: a 45-min interview at the largest whisper model runs ~1-1.5h (plus ~1-1.5h of diarization). Until now there was no way to stop and continue — the whisper subprocess ran to completion or died leaving nothing, so a thermal throttle, a closed laptop, or any interruption meant redoing hours of compute. The primary need is a **deliberate pause** ("laptop is too hot, stop now, finish tonight"), not just crash recovery.

## How it works

whisper.cpp's CLI can't resume mid-subprocess, but it does two things we now exploit (verified against upstream `cli.cpp` and the local binary):
- It **streams each completed segment to stdout** (with `fflush`) even when writing JSON to a file — pidcast previously discarded this with `stdout=DEVNULL`.
- It supports **`-ot <ms>`** to start decoding at a time offset, emitting **absolute** timestamps.

So: tee whisper's stdout, persist each segment to a per-job checkpoint as it decodes, and on resume re-invoke with `-ot <last-good-ms>` and concatenate. No audio splitting, one resume seam.

## User-facing impact

- **Ctrl-C during transcription pauses and saves** instead of losing everything; prints the resume hint. A second Ctrl-C force-quits.
- **`pidcast resume`** auto-detects the most recent paused job and continues it — no input/flags to retype (stored in the manifest). Loses at most the in-flight segment (a few seconds).
- New flags: `--no-checkpoint` (one-shot, prior behavior) and `--keep-checkpoint` (retain the job dir after success).
- Uninterrupted runs are unchanged; checkpoints live in the XDG config dir (`~/.config/pidcast/checkpoints/`) and are deleted on success.

## Limits (by design)

- Resume granularity is the **transcription phase**. pyannote diarization is one indivisible global-clustering call with no offset hook, so an interruption during diarization restarts it from scratch — but the hours of whisper work are preserved, and the job re-enters diarization directly without re-transcribing.
- With `--vad`, the resume offset is backed off a few seconds and re-decoded segments are de-overlapped on merge, because VAD can shift the seam boundary and swallow audio (observed in a spike).

## Testing

- 23 new unit tests (segment parsing incl. `.`/`,` ms separators, timestamp rendering, de-overlapping merge with the `offsets` dict schema diarization needs, manifest JSONL round-trip, partial-line tolerance, resumable-job discovery, corrupt-manifest skip, streaming + pause loop against a fake whisper binary). Full suite: **340 passed**, ruff clean.
- Real e2e on a 47-min interview WAV: full checkpointed run produced a correct transcript with monotonic timestamps and cleaned the checkpoint on success; SIGINT at 90s cleanly paused (216 segments saved up to 14:41, manifest + JSONL + source.wav persisted, no failure stat). The resume half is being validated separately.

## Files

- New: `checkpoint.py` (JobManifest + JSONL store + job-id/signature + discovery/cleanup), `resume.py` (`pidcast resume` arg reconstruction + preflight).
- Changed: `transcription.py` (stdout streaming, `-ot`, tolerant parser, merge helpers), `whisper_provider.py` (checkpoint-aware transcribe), `workflow.py` (manifest lifecycle, pause sentinel, cleanup), `cli.py` (resume subcommand, SIGINT handler, flags), `exceptions.py`, `config.py`.

Minor bump: 0.9.3 → 0.10.0.