### PR TITLE
fix: rework duplicate detection, stats integrity, and stale copy/logging (#20 #21 #22 #23)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidcast"
-version = "0.10.2"
+version = "0.11.0"
 description = "YouTube transcription tool with Whisper and LLM analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pidcast/cli.py
+++ b/src/pidcast/cli.py
@@ -75,7 +75,7 @@ def prompt_duplicate_detected(
     console.print(
         Panel(
             "[yellow bold]Duplicate Detected![/yellow bold]\n\n"
-            "This video was previously transcribed.",
+            "This recording was previously transcribed.",
             border_style="yellow",
         )
     )
@@ -105,7 +105,7 @@ def prompt_duplicate_detected(
     # Build options
     console.print("[bold]What would you like to do?[/bold]")
     console.print()
-    console.print("  [cyan]1[/cyan] - Re-transcribe the video")
+    console.print("  [cyan]1[/cyan] - Re-transcribe the recording")
 
     if transcript_exists:
         console.print("  [cyan]2[/cyan] - Analyze existing transcript (skip re-transcription)")
@@ -149,7 +149,7 @@ def _prompt_duplicate_basic(prev) -> DuplicateAction:
     print(f"File: {prev.smart_filename}")
     print()
     print("Options:")
-    print("  1 - Re-transcribe the video")
+    print("  1 - Re-transcribe the recording")
     print("  2 - Analyze existing transcript")
     print("  3 - Continue anyway")
     print("  4 - Cancel")
@@ -1377,12 +1377,18 @@ def cmd_sync(args: argparse.Namespace) -> None:
             traceback.print_exc()
 
 
-def cmd_doctor() -> None:
+def cmd_doctor(prune_stats: bool = False) -> None:
     """Run health checks and display configuration status."""
+    from .config import DEFAULT_STATS_FILE
     from .setup import determine_status, run_all_checks
+    from .utils import prune_phantom_stats
 
     print("\npidcast doctor")
     print("=" * 40)
+
+    if prune_stats:
+        removed = prune_phantom_stats(DEFAULT_STATS_FILE)
+        print(f"  Pruned {removed} phantom stats entr(y/ies) with a missing transcript.\n")
 
     checks = run_all_checks()
     max_name = max(len(c.name) for c in checks)
@@ -1538,12 +1544,16 @@ def main() -> None:
             from dotenv import load_dotenv
 
             load_dotenv()
-            cmd_doctor()
+            # doctor/setup dispatch before parse_arguments()/setup_logging(), so
+            # configure logging here or logger.* output is silently dropped.
+            setup_logging("--verbose" in sys.argv or "-v" in sys.argv)
+            cmd_doctor(prune_stats="--prune-stats" in sys.argv)
             return
         if sys.argv[1] == "setup":
             from dotenv import load_dotenv
 
             load_dotenv()
+            setup_logging("--verbose" in sys.argv or "-v" in sys.argv)
             cmd_setup()
             return
         if sys.argv[1] == "resume":

--- a/src/pidcast/config.py
+++ b/src/pidcast/config.py
@@ -357,6 +357,13 @@ class TranscriptionStats:
     saved_to_obsidian: bool = False
     is_local_file: bool = False
     analysis_only: bool = False
+    # Full resolved path to the written transcript (absolute). Lets duplicate
+    # detection locate the artifact regardless of the cwd/output-dir of a later
+    # run; smart_filename alone is just a basename and resolves wrong elsewhere.
+    transcript_path: str | None = None
+    # Stable source identifier for duplicate matching across all input types
+    # (YouTube id, RSS/Apple GUID, normalized url, or local abs path).
+    source_id: str | None = None
     # Analysis metadata
     analysis_performed: bool = False
     analysis_type: str | None = None
@@ -392,6 +399,8 @@ class TranscriptionStats:
             "saved_to_obsidian": self.saved_to_obsidian,
             "is_local_file": self.is_local_file,
             "analysis_only": self.analysis_only,
+            "transcript_path": self.transcript_path,
+            "source_id": self.source_id,
             "analysis_performed": self.analysis_performed,
             "analysis_type": self.analysis_type,
             "analysis_name": self.analysis_name,
@@ -423,10 +432,15 @@ class PreviousTranscription:
     output_dir: Path
     analysis_performed: bool = False
     analysis_type: str | None = None
+    # Resolved transcript path from the stats entry (full path survives a different
+    # cwd/output-dir); falls back to output_dir/smart_filename when absent.
+    transcript_path_override: Path | None = None
 
     @property
     def transcript_path(self) -> Path:
         """Full path to the transcript file."""
+        if self.transcript_path_override is not None:
+            return self.transcript_path_override
         return self.output_dir / self.smart_filename
 
     @property

--- a/src/pidcast/resume.py
+++ b/src/pidcast/resume.py
@@ -90,9 +90,12 @@ def resume_job(manifest: JobManifest) -> None:
     else:
         from .providers.whisper_provider import _fmt_clock
 
+        # Count from the JSONL (the source of truth), not the manifest's counter,
+        # so "N segments done" always agrees with the resume offset.
+        segments = manifest.load_segments()
         offset_ms = manifest.resume_offset_ms()
         logger.info(
-            f"Job {manifest.job_id} - {manifest.transcription.segment_count} segments done, "
+            f"Job {manifest.job_id} - {len(segments)} segments done, "
             f"continuing from {_fmt_clock(offset_ms)}."
         )
 

--- a/src/pidcast/setup.py
+++ b/src/pidcast/setup.py
@@ -142,6 +142,26 @@ def check_env_file() -> CheckResult:
     )
 
 
+def check_stats_integrity() -> CheckResult:
+    """Check for phantom stats entries (success recorded, transcript file gone)."""
+    from .config import DEFAULT_STATS_FILE
+    from .utils import find_phantom_stats
+
+    try:
+        phantoms = find_phantom_stats(DEFAULT_STATS_FILE)
+    except Exception as e:
+        return CheckResult("stats integrity", True, f"skipped ({e})", required=False)
+    if not phantoms:
+        return CheckResult("stats integrity", True, "ok (no phantom entries)", required=False)
+    return CheckResult(
+        "stats integrity",
+        False,
+        f"{len(phantoms)} stats entr(y/ies) point at a missing transcript",
+        hint="These block duplicate detection. Clean them with: pidcast doctor --prune-stats",
+        required=False,
+    )
+
+
 def run_all_checks() -> list[CheckResult]:
     """Run all health checks and return results."""
     return [
@@ -150,6 +170,7 @@ def run_all_checks() -> list[CheckResult]:
         check_whisper(),
         check_whisper_model(),
         check_vad_model(),
+        check_stats_integrity(),
         check_env_var(
             "GROQ_API_KEY",
             "GROQ_API_KEY",

--- a/src/pidcast/utils.py
+++ b/src/pidcast/utils.py
@@ -413,6 +413,50 @@ def extract_youtube_video_id(url: str) -> str | None:
         return None
 
 
+def compute_source_id(input_source: str) -> str:
+    """Stable identifier for an input, for duplicate detection across all source types.
+
+    - Local file -> ``file:<absolute-path>``
+    - YouTube URL -> ``yt:<video-id>`` (normalized, strips tracking params)
+    - Apple Podcasts URL -> ``apple:<collection-id>:<track-id>``
+    - Any other URL -> ``url:<scheme://host/path>`` (query/fragment stripped, lowercased host)
+    - Fallback -> the raw string
+
+    Used both when writing a stats entry and when checking for a duplicate, so the
+    two always agree. Replaces the old YouTube-only matching that silently failed
+    for podcasts, RSS items, and direct media URLs.
+    """
+    if os.path.exists(input_source):
+        return f"file:{os.path.abspath(input_source)}"
+
+    yt = extract_youtube_video_id(input_source)
+    if yt:
+        return f"yt:{yt}"
+
+    # Apple Podcasts: match by collection/track id, not the full marketing URL.
+    try:
+        from .apple_podcasts import is_apple_podcasts_url, parse_apple_podcasts_url
+
+        if is_apple_podcasts_url(input_source):
+            collection_id, track_id = parse_apple_podcasts_url(input_source)
+            return f"apple:{collection_id}:{track_id or ''}"
+    except Exception:
+        pass
+
+    # Generic URL: normalize to scheme://host/path, dropping query/fragment and
+    # case-folding the host so equivalent links collapse to one id.
+    try:
+        parsed = urlparse(input_source)
+        if parsed.scheme and parsed.netloc:
+            host = parsed.netloc.lower()
+            path = parsed.path.rstrip("/")
+            return f"url:{parsed.scheme.lower()}://{host}{path}"
+    except Exception:
+        pass
+
+    return input_source
+
+
 def find_existing_transcription(
     stats_file: Path,
     input_source: str,
@@ -430,58 +474,41 @@ def find_existing_transcription(
     """
     from .config import PreviousTranscription
 
-    # Load stats
     stats = load_json_file(stats_file, default=[])
     if not stats:
         return None
 
-    # Determine what to match on
-    if os.path.exists(input_source):
-        # Local file: match by absolute path
-        abs_path = os.path.abspath(input_source)
-        for entry in reversed(stats):  # Most recent first
-            entry_url = entry.get("video_url", "")
-            if (
-                entry.get("is_local_file")
-                and os.path.abspath(entry_url) == abs_path
-                and entry.get("success")
-                and entry.get("smart_filename")
-            ):
-                return PreviousTranscription(
-                    video_id="",
-                    video_title=entry.get("video_title", "Unknown"),
-                    video_url=entry_url,
-                    run_timestamp=entry.get("run_timestamp", ""),
-                    smart_filename=entry.get("smart_filename", ""),
-                    output_dir=output_dir,
-                    analysis_performed=entry.get("analysis_performed", False),
-                    analysis_type=entry.get("analysis_type"),
-                )
-    else:
-        # YouTube URL: match by normalized video ID
-        current_video_id = extract_youtube_video_id(input_source)
-        if not current_video_id:
-            return None
+    current_id = compute_source_id(input_source)
 
-        for entry in reversed(stats):  # Most recent first
-            entry_url = entry.get("video_url", "")
-            entry_video_id = extract_youtube_video_id(entry_url)
+    for entry in reversed(stats):  # Most recent first
+        if not (entry.get("success") and entry.get("smart_filename")):
+            continue
 
-            if (
-                entry_video_id == current_video_id
-                and entry.get("success")
-                and entry.get("smart_filename")
-            ):
-                return PreviousTranscription(
-                    video_id=current_video_id,
-                    video_title=entry.get("video_title", "Unknown"),
-                    video_url=entry_url,
-                    run_timestamp=entry.get("run_timestamp", ""),
-                    smart_filename=entry.get("smart_filename", ""),
-                    output_dir=output_dir,
-                    analysis_performed=entry.get("analysis_performed", False),
-                    analysis_type=entry.get("analysis_type"),
-                )
+        # Match by stable source id. Fall back to recomputing the id from the
+        # entry's stored url for older entries written before source_id existed.
+        entry_id = entry.get("source_id") or compute_source_id(entry.get("video_url", ""))
+        if entry_id != current_id:
+            continue
+
+        # Validate the artifact still exists before calling it a duplicate -
+        # a missing transcript must NOT block re-transcription (issue #20). Prefer
+        # the full stored path; fall back to <output_dir>/<smart_filename>.
+        stored_path = entry.get("transcript_path")
+        candidate = Path(stored_path) if stored_path else (output_dir / entry["smart_filename"])
+        if not candidate.exists():
+            continue
+
+        return PreviousTranscription(
+            video_id=entry.get("source_id", ""),
+            video_title=entry.get("video_title", "Unknown"),
+            video_url=entry.get("video_url", ""),
+            run_timestamp=entry.get("run_timestamp", ""),
+            smart_filename=entry.get("smart_filename", ""),
+            output_dir=output_dir,
+            analysis_performed=entry.get("analysis_performed", False),
+            analysis_type=entry.get("analysis_type"),
+            transcript_path_override=candidate,
+        )
 
     return None
 
@@ -521,6 +548,36 @@ def cleanup_temp_files(audio_file: str | Path, verbose: bool = False) -> None:
 # ============================================================================
 # STATISTICS
 # ============================================================================
+
+
+def find_phantom_stats(stats_file: Path) -> list[dict]:
+    """Return successful stats entries whose transcript file no longer exists.
+
+    These are the entries that pollute duplicate detection (a "duplicate" pointing
+    at a missing file). Uses the full ``transcript_path`` when present; older
+    entries with only a basename can't be located, so they are NOT reported as
+    phantoms (we can't prove they're missing).
+    """
+    stats = load_json_file(stats_file, default=[])
+    return [e for e in stats if _is_phantom(e)]
+
+
+def _is_phantom(entry: dict) -> bool:
+    """A successful stat whose recorded full transcript path no longer exists."""
+    if not (entry.get("success") and entry.get("smart_filename")):
+        return False
+    path = entry.get("transcript_path")
+    return bool(path) and not Path(path).exists()
+
+
+def prune_phantom_stats(stats_file: Path, verbose: bool = False) -> int:
+    """Drop successful stats entries whose transcript file is gone. Returns count removed."""
+    stats = load_json_file(stats_file, default=[])
+    kept = [e for e in stats if not _is_phantom(e)]
+    removed = len(stats) - len(kept)
+    if removed:
+        save_json_file(stats_file, kept, verbose=verbose)
+    return removed
 
 
 def save_statistics(stats_file: Path, stats: "TranscriptionStats", verbose: bool = False) -> bool:

--- a/src/pidcast/workflow.py
+++ b/src/pidcast/workflow.py
@@ -551,6 +551,7 @@ def run_analyze_existing_mode(
 
         # Store the original transcript filename
         transcript_filename = Path(transcript_path).name
+        from .utils import compute_source_id
 
         stats = TranscriptionStats(
             run_uid=run_uid,
@@ -565,6 +566,8 @@ def run_analyze_existing_mode(
             saved_to_obsidian=args.save_to_obsidian,
             is_local_file=True,
             analysis_only=True,
+            transcript_path=str(Path(transcript_path).resolve()),
+            source_id=compute_source_id(str(transcript_path)),
             analysis_performed=True,
             analysis_type=analysis_metadata.get("analysis_type"),
             analysis_name=analysis_metadata.get("analysis_name"),
@@ -1220,23 +1223,40 @@ def process_input_source(
             if args.verbose:
                 log_success(f"Kept transcript file: {transcript_file}")
 
-        # Store statistics
+        # Store statistics. Guard: never record success unless the transcript
+        # actually exists at its final path - otherwise a missing/misplaced .md
+        # becomes a phantom "duplicate" that blocks future re-transcription.
+        if not markdown_file or not Path(markdown_file).exists():
+            raise FileProcessingError(
+                f"Transcript file was not written to its expected path: {markdown_file}"
+            )
+
         end_time = time.time()
         duration = end_time - start_time
         filename_for_stats = markdown_file.name if markdown_file else ""
+
+        # On resume, key the stat to the ORIGINAL source (from the manifest's
+        # video_info), not the checkpoint source.wav, so duplicate detection matches
+        # the user's real input later.
+        stats_source = input_source
+        if video_info_override and video_info_override.webpage_url:
+            stats_source = video_info_override.webpage_url
+        from .utils import compute_source_id
 
         stats = TranscriptionStats(
             run_uid=run_uid,
             run_timestamp=run_timestamp,
             video_title=video_info.title,
             smart_filename=filename_for_stats,
-            video_url=input_source,
+            video_url=stats_source,
             run_duration=duration,
             transcription_duration=transcription_duration,
             audio_duration=audio_duration,
             success=True,
             saved_to_obsidian=args.save_to_obsidian,
             is_local_file=is_local_file,
+            transcript_path=str(Path(markdown_file).resolve()),
+            source_id=compute_source_id(stats_source),
             analysis_performed=analysis_performed,
             analysis_type=analysis_metadata.get("analysis_type"),
             analysis_name=analysis_metadata.get("analysis_name"),

--- a/tests/test_duplicate_detection.py
+++ b/tests/test_duplicate_detection.py
@@ -1,0 +1,202 @@
+"""Tests for duplicate detection, source-id matching, and stats reconciliation.
+
+Covers the rework from issues #20-#23:
+- compute_source_id normalizes every input type (not just YouTube)
+- find_existing_transcription matches by source_id and validates the artifact
+- phantom stats (success recorded, file gone) don't block re-transcription
+- prune/find phantom helpers
+"""
+
+from __future__ import annotations
+
+import json
+
+from pidcast.utils import (
+    compute_source_id,
+    find_existing_transcription,
+    find_phantom_stats,
+    prune_phantom_stats,
+)
+
+# ---------------------------------------------------------------------------
+# compute_source_id
+# ---------------------------------------------------------------------------
+
+
+def test_source_id_youtube_normalizes_formats():
+    a = compute_source_id("https://youtu.be/dQw4w9WgXcQ?si=tracking")
+    b = compute_source_id("https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=shared")
+    assert a == b == "yt:dQw4w9WgXcQ"
+
+
+def test_source_id_generic_url_strips_query_and_fragment():
+    a = compute_source_id("https://feeds.example.com/ep/123.mp3?token=abc")
+    b = compute_source_id("https://feeds.example.com/ep/123.mp3?token=different#t=10")
+    # Same episode, different tracking params -> same id (podcasts/RSS now dedup).
+    assert a == b == "url:https://feeds.example.com/ep/123.mp3"
+
+
+def test_source_id_local_file(tmp_path):
+    f = tmp_path / "rec.wav"
+    f.write_bytes(b"x")
+    assert compute_source_id(str(f)) == f"file:{f.resolve()}"
+
+
+def test_source_id_apple_podcasts():
+    # Apple URL keyed by collection/track id, not the marketing slug.
+    sid = compute_source_id("https://podcasts.apple.com/us/podcast/some-show/id12345?i=67890")
+    assert sid.startswith("apple:12345")
+
+
+# ---------------------------------------------------------------------------
+# find_existing_transcription
+# ---------------------------------------------------------------------------
+
+
+def _write_stats(stats_file, entries):
+    stats_file.write_text(json.dumps(entries), encoding="utf-8")
+
+
+def test_finds_duplicate_for_non_youtube_url(tmp_path):
+    # Regression for #21: a podcast/RSS URL must be detectable as a duplicate.
+    out = tmp_path / "out"
+    out.mkdir()
+    md = out / "2026-06-24_episode.md"
+    md.write_text("transcript", encoding="utf-8")
+    stats = tmp_path / "stats.json"
+    url = "https://feeds.example.com/ep/123.mp3"
+    _write_stats(
+        stats,
+        [
+            {
+                "video_title": "Episode 123",
+                "smart_filename": "2026-06-24_episode.md",
+                "video_url": url,
+                "source_id": compute_source_id(url),
+                "transcript_path": str(md),
+                "success": True,
+                "run_timestamp": "2026-06-24T10:00:00",
+            }
+        ],
+    )
+    prev = find_existing_transcription(stats, url + "?utm=x", out)
+    assert prev is not None
+    assert prev.video_title == "Episode 123"
+
+
+def test_missing_transcript_is_not_a_duplicate(tmp_path):
+    # Regression for #20: a phantom entry must NOT block re-transcription.
+    out = tmp_path / "out"
+    out.mkdir()
+    stats = tmp_path / "stats.json"
+    url = "https://youtu.be/dQw4w9WgXcQ"
+    _write_stats(
+        stats,
+        [
+            {
+                "video_title": "Gone",
+                "smart_filename": "2026-06-24_gone.md",
+                "video_url": url,
+                "source_id": compute_source_id(url),
+                "transcript_path": str(out / "2026-06-24_gone.md"),  # never created
+                "success": True,
+                "run_timestamp": "2026-06-24T10:00:00",
+            }
+        ],
+    )
+    assert find_existing_transcription(stats, url, out) is None
+
+
+def test_full_path_survives_different_output_dir(tmp_path):
+    # The stored transcript_path lets detection find the file even when the
+    # current output_dir differs from where it was originally written.
+    real_out = tmp_path / "real"
+    real_out.mkdir()
+    md = real_out / "2026-06-24_x.md"
+    md.write_text("t", encoding="utf-8")
+    other_out = tmp_path / "elsewhere"
+    other_out.mkdir()
+    stats = tmp_path / "stats.json"
+    url = "https://youtu.be/abcdef12345"
+    _write_stats(
+        stats,
+        [
+            {
+                "video_title": "X",
+                "smart_filename": "2026-06-24_x.md",
+                "video_url": url,
+                "source_id": compute_source_id(url),
+                "transcript_path": str(md),
+                "success": True,
+                "run_timestamp": "2026-06-24T10:00:00",
+            }
+        ],
+    )
+    # Running from a different output dir still finds the duplicate.
+    prev = find_existing_transcription(stats, url, other_out)
+    assert prev is not None
+    assert prev.transcript_path == md
+
+
+def test_legacy_entry_without_source_id_still_matches(tmp_path):
+    # Older entries (no source_id) fall back to recomputing from video_url.
+    out = tmp_path / "out"
+    out.mkdir()
+    md = out / "old.md"
+    md.write_text("t", encoding="utf-8")
+    stats = tmp_path / "stats.json"
+    url = "https://youtu.be/legacy00000"
+    _write_stats(
+        stats,
+        [
+            {
+                "video_title": "Old",
+                "smart_filename": "old.md",
+                "video_url": url,
+                "success": True,
+                "run_timestamp": "2026-06-24T10:00:00",
+            }
+        ],
+    )
+    prev = find_existing_transcription(stats, url, out)
+    assert prev is not None
+
+
+# ---------------------------------------------------------------------------
+# phantom stats reconciliation
+# ---------------------------------------------------------------------------
+
+
+def test_find_and_prune_phantom_stats(tmp_path):
+    out = tmp_path / "out"
+    out.mkdir()
+    present = out / "present.md"
+    present.write_text("t", encoding="utf-8")
+    stats = tmp_path / "stats.json"
+    _write_stats(
+        stats,
+        [
+            {"smart_filename": "present.md", "transcript_path": str(present), "success": True},
+            {"smart_filename": "gone.md", "transcript_path": str(out / "gone.md"), "success": True},
+            {"smart_filename": "failed.md", "transcript_path": None, "success": False},
+        ],
+    )
+    phantoms = find_phantom_stats(stats)
+    assert len(phantoms) == 1
+    assert phantoms[0]["smart_filename"] == "gone.md"
+
+    removed = prune_phantom_stats(stats)
+    assert removed == 1
+    remaining = json.loads(stats.read_text())
+    names = {e["smart_filename"] for e in remaining}
+    assert names == {"present.md", "failed.md"}
+
+
+def test_prune_noop_when_no_phantoms(tmp_path):
+    stats = tmp_path / "stats.json"
+    present = tmp_path / "a.md"
+    present.write_text("t", encoding="utf-8")
+    _write_stats(
+        stats, [{"smart_filename": "a.md", "transcript_path": str(present), "success": True}]
+    )
+    assert prune_phantom_stats(stats) == 0


### PR DESCRIPTION
Closes #20, #21, #22, #23.

The duplicate-detection + stats subsystem predated pidcast supporting podcasts, local files, and RSS, and had silently rotted — surfaced while validating the pause/resume feature (#19).

## #21 — Duplicate detection works for all input types, not just YouTube

New `compute_source_id()` normalizes any input to a stable key:
- `yt:<id>` — YouTube (strips `?si=`/`&feature=` tracking)
- `apple:<collection>:<track>` — Apple Podcasts
- `url:<scheme://host/path>` — RSS / direct media (drops query+fragment, so the same episode with different tokens collapses to one id)
- `file:<abspath>` — local files

Matching is keyed on this id. **Before:** anything that wasn't a YouTube URL returned `None` from `find_existing_transcription` — so re-running a podcast episode silently created a duplicate transcript. **After:** it's correctly detected.

## #20 — Missing transcripts no longer block re-transcription

A stats entry is treated as a duplicate only if the transcript file actually exists. Stats now store the full resolved `transcript_path`, so detection finds the artifact even when run from a different cwd/output-dir (the original phantom-duplicate cause). On resume, stats key to the **original** source url (from the manifest), not the checkpoint `source.wav`.

## #22 — Stats are truthful and reconcilable

- `success: true` is never written unless the `.md` exists at its final path (guarded before the stat is saved).
- New `find_phantom_stats` / `prune_phantom_stats` helpers.
- `pidcast doctor` gains a **stats integrity** check; `pidcast doctor --prune-stats` cleans entries whose transcript is gone.

## #23 — Stale copy + silent subcommands

- Duplicate prompts say "recording" instead of "video".
- `doctor` and `setup` now configure logging on dispatch (they ran silently before, same gap `resume` had).
- Resume banner counts segments from the JSONL source of truth, so "N segments done" agrees with the resume offset.

## User-facing impact

- Re-running a podcast / RSS / local recording is correctly flagged as a duplicate.
- A lost or moved transcript no longer blocks you from re-transcribing it.
- `pidcast doctor` reports (and `--prune-stats` cleans) phantom entries.
- `doctor`/`setup` output is visible; duplicate prompts read correctly for any source.

## Tests

12 new tests: source-id normalization across all input types, cross-output-dir matching, phantom handling, legacy entries (no `source_id`), and prune/reconcile. Full suite 352 + new = green; ruff clean.

Note: backward-compatible — older stats entries without `source_id`/`transcript_path` fall back to recomputing the id from `video_url` and validating via `output_dir/smart_filename`.