### PR TITLE
feat: whisper --prompt glossary biasing for domain terms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,3 +80,4 @@ Source lives under `src/pidcast/`. Hot-path modules (read these first when debug
 - [docs/adr/](docs/adr/) — Architecture Decision Records (provider abstractions)
 - `config/prompts.yaml` — analysis prompt templates
 - `config/models.yaml` — LLM model definitions and fallback chains
+- `config/glossaries.yaml` — named domain glossaries for whisper `--prompt` biasing (used via `--glossary`)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ uv run pidcast "/path/to/meeting.mp3" --tags meeting,standup,weekly
 # Test settings on a 2-minute slice before committing to a long run
 uv run pidcast "URL" --test-segment
 
+# Bias transcription toward domain terms (proper nouns, jargon) via whisper --prompt.
+# Cheapest accuracy win for niche vocabulary - beats jumping to a bigger model.
+uv run pidcast "/path/to/interview.mp3" --glossary adtech-ai     # named glossary from config/glossaries.yaml
+uv run pidcast "URL" --whisper-prompt "Names: Acme, Foobar, gRPC."  # raw inline prompt
+
 # Reuse an existing transcript
 uv run pidcast --analyze-existing transcript.md          # re-analyze
 uv run pidcast --diarize-existing transcript.md          # retry diarization

--- a/config/glossaries.yaml
+++ b/config/glossaries.yaml
@@ -1,0 +1,18 @@
+# Pidcast transcription glossaries
+#
+# Each glossary is a short natural-language string fed to whisper.cpp via --prompt
+# to bias decoding toward domain terms (proper nouns and jargon it otherwise
+# mis-transcribes). Use with `--glossary <name>` on the main command.
+#
+# Whisper conditions on PROSE, not word lists - write a sentence. Keep it short:
+# the prompt is capped at roughly half the model's text context (~200+ tokens) and
+# longer text is silently truncated. Bias is probabilistic, not a hard dictionary.
+# Include the proper nouns whisper actually gets wrong; skip common English words
+# it already knows (they just waste the token budget).
+
+glossaries:
+  # Ad tech + AI interview vocabulary (Ostap's recurring proper nouns).
+  adtech-ai: >-
+    This is an interview about ad tech and AI. Names: Sabre, Sizmek, Xenoss,
+    StrikeAd, Voicemod, Kasta, Satori, OpenClaw, Claude Code, agentic, evals,
+    MCP server, OpenRTB, Protobuf, GDS, gcloud, DSP, SSP.

--- a/src/pidcast/cli.py
+++ b/src/pidcast/cli.py
@@ -566,6 +566,22 @@ Short Flags:
         default=8,
         help="Number of whisper decoding threads (whisper -t). Default: 8.",
     )
+    whisper_quality.add_argument(
+        "--whisper-prompt",
+        dest="whisper_prompt",
+        default=None,
+        help="Raw initial-prompt text passed to whisper --prompt to bias decoding "
+        "toward domain terms (proper nouns, jargon). Limited to roughly half the "
+        "model's text context (~200+ tokens); keep it short. Overrides --glossary.",
+    )
+    whisper_quality.add_argument(
+        "--glossary",
+        dest="glossary",
+        default=None,
+        help="Name of a glossary from config/glossaries.yaml (e.g. 'adtech-ai') to "
+        "bias transcription via whisper --prompt. NOTE: pair English-only (.en) "
+        "models with English audio only.",
+    )
     parser.add_argument(
         "--front-matter",
         dest="front_matter",

--- a/src/pidcast/config.py
+++ b/src/pidcast/config.py
@@ -1,12 +1,16 @@
 """Configuration constants and loading for pidcast."""
 
+import logging
 import os
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import yaml
 from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
 
 # ============================================================================
 # PATH RESOLUTION
@@ -53,6 +57,7 @@ DEFAULT_TRANSCRIPTS_DIR = PROJECT_ROOT / "data" / "transcripts"
 DEFAULT_STATS_FILE = DEFAULT_TRANSCRIPTS_DIR / "transcription_stats.json"
 DEFAULT_PROMPTS_FILE = PROJECT_ROOT / "config" / "prompts.yaml"
 DEFAULT_MODELS_FILE = PROJECT_ROOT / "config" / "models.yaml"
+DEFAULT_GLOSSARIES_FILE = PROJECT_ROOT / "config" / "glossaries.yaml"
 DEFAULT_DIGESTS_DIR = DEFAULT_TRANSCRIPTS_DIR  # Digests saved alongside transcripts
 
 # Deprecated: kept for backward compatibility
@@ -503,3 +508,36 @@ class PromptsConfig:
                 max_output_tokens=value.get("max_output_tokens", 2000),
             )
         return cls(prompts=prompts)
+
+
+def load_glossaries(config_path: Path = DEFAULT_GLOSSARIES_FILE) -> dict[str, str]:
+    """Load named transcription glossaries from YAML.
+
+    Glossaries are short natural-language strings fed to whisper via --prompt to
+    bias decoding toward domain terms. Unlike the models/prompts config, a missing
+    or invalid file is non-fatal: it just means no glossaries are available, so the
+    transcription path keeps working unbiased.
+
+    Args:
+        config_path: Path to glossaries.yaml.
+
+    Returns:
+        Mapping of glossary name -> prompt text. Empty dict if the file is missing,
+        empty, or invalid.
+    """
+    if not config_path.exists():
+        return {}
+
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except (yaml.YAMLError, OSError) as e:
+        logger.error("Invalid glossaries config (%s): %s", config_path, e)
+        return {}
+
+    if not data:
+        return {}
+
+    glossaries = data.get("glossaries", {})
+    # Normalize to str values; drop anything non-string defensively.
+    return {name: str(text).strip() for name, text in glossaries.items() if text}

--- a/src/pidcast/transcription.py
+++ b/src/pidcast/transcription.py
@@ -641,6 +641,7 @@ def run_whisper_transcription(
     temperature: float | None = None,
     no_fallback: bool = False,
     suppress_nst: bool = False,
+    prompt: str | None = None,
     audio_duration: float | None = None,
     offset_ms: int | None = None,
     segment_callback: "Callable[[dict], None] | None" = None,
@@ -670,6 +671,12 @@ def run_whisper_transcription(
         no_fallback: Disable temperature fallback while decoding (whisper -nf).
         suppress_nst: Suppress non-speech tokens (whisper -sns). Reduces boilerplate
             hallucinations on low-speech audio.
+        prompt: Initial-prompt text passed to whisper --prompt to bias decoding
+            toward domain terms (proper nouns, jargon). None omits the flag. When
+            set, --carry-initial-prompt is also passed so the bias persists across
+            all decode windows, not just the first (whisper applies the initial
+            prompt only to the first window otherwise). Limited to roughly half the
+            model's text context (~200+ tokens); longer prompts are truncated.
         offset_ms: Resume offset in milliseconds (whisper -ot). Decoding starts here;
             emitted timestamps remain absolute (relative to file start).
         segment_callback: Invoked once per completed segment as it streams off
@@ -713,6 +720,12 @@ def run_whisper_transcription(
         command.extend(["--vad", "-vm", str(vad_model)])
         if vad_threshold is not None:
             command.extend(["-vt", str(vad_threshold)])
+
+    # Glossary/initial-prompt biasing. --carry-initial-prompt makes whisper apply
+    # the prompt to every decode window (not just the first), so the bias holds
+    # across a long file. NOTE: -p is --processors, NOT prompt - do not use it.
+    if prompt:
+        command.extend(["--prompt", prompt, "--carry-initial-prompt"])
 
     # Resume: start decoding at a time offset. whisper.cpp emits ABSOLUTE
     # timestamps under -ot (verified), so the streamed segments need no

--- a/src/pidcast/workflow.py
+++ b/src/pidcast/workflow.py
@@ -19,6 +19,7 @@ from .apple_podcasts import is_apple_podcasts_url, resolve_apple_podcasts_url
 from .config import (
     TranscriptionStats,
     VideoInfo,
+    load_glossaries,
 )
 from .download import download_audio
 from .exceptions import (
@@ -837,6 +838,44 @@ def run_diarize_existing_mode(
         return False
 
 
+def _resolve_whisper_prompt(args: argparse.Namespace) -> str | None:
+    """Resolve the whisper initial-prompt from CLI args.
+
+    Precedence: an explicit --whisper-prompt wins over --glossary (and warns if
+    both are given). A --glossary name is looked up in config/glossaries.yaml; an
+    unknown name is fatal (raises ConfigurationError) before transcription starts,
+    so a typo fails loudly with the available names rather than silently running
+    unbiased. Returns None when neither is set (command stays byte-identical).
+    """
+    whisper_prompt = getattr(args, "whisper_prompt", None)
+    glossary = getattr(args, "glossary", None)
+
+    if whisper_prompt and glossary:
+        logger.warning("--whisper-prompt overrides --glossary")
+        return whisper_prompt
+    if whisper_prompt:
+        return whisper_prompt
+    if not glossary:
+        return None
+
+    glossaries = load_glossaries()
+    if glossary not in glossaries:
+        available = ", ".join(sorted(glossaries)) or "(none configured)"
+        raise ConfigurationError(f"Unknown glossary {glossary!r}. Available: {available}")
+
+    # Computable .en/language mismatch warning: an English-only model fed a
+    # non-English language with an English glossary compounds errors.
+    language = getattr(args, "language", None)
+    model = str(getattr(args, "whisper_model", "") or "")
+    if language and not language.lower().startswith("en") and ".en" in model:
+        logger.warning(
+            ".en model with non-English language (%s) + glossary may degrade output",
+            language,
+        )
+
+    return glossaries[glossary]
+
+
 def process_input_source(
     input_source: str,
     args: argparse.Namespace,
@@ -1050,6 +1089,7 @@ def process_input_source(
                 "temperature": getattr(args, "temperature", None),
                 "no_fallback": getattr(args, "no_fallback", False),
                 "suppress_nst": getattr(args, "suppress_nst", True),
+                "prompt": _resolve_whisper_prompt(args),
             }
 
             # Set up the resume/pause checkpoint (whisper only). Disabled for

--- a/tests/test_whisper_prompt.py
+++ b/tests/test_whisper_prompt.py
@@ -1,0 +1,134 @@
+"""Tests for whisper --prompt glossary biasing (CLI -> resolver -> argv)."""
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+from pidcast.config import load_glossaries
+from pidcast.exceptions import ConfigurationError
+from pidcast.transcription import run_whisper_transcription
+from pidcast.workflow import _resolve_whisper_prompt
+
+# ============================================================================
+# argv construction: the real contract is what lands in the whisper command
+# ============================================================================
+
+
+def _capture_command(**kwargs):
+    """Run run_whisper_transcription with the streaming layer mocked and return
+    the command list it built."""
+    with patch("pidcast.transcription._run_whisper_streaming") as mock_stream:
+        run_whisper_transcription(
+            "audio.wav",
+            "ggml-small.en.bin",
+            "txt",
+            "out",
+            show_progress=False,
+            **kwargs,
+        )
+        # command is the first positional arg to _run_whisper_streaming
+        return mock_stream.call_args[0][0]
+
+
+class TestWhisperPromptArgv:
+    def test_prompt_emits_flag_and_carry(self):
+        cmd = _capture_command(prompt="Names: Sabre, Xenoss.")
+        assert "--prompt" in cmd
+        # text follows the flag immediately
+        assert cmd[cmd.index("--prompt") + 1] == "Names: Sabre, Xenoss."
+        # carry-initial-prompt keeps the bias across all windows
+        assert "--carry-initial-prompt" in cmd
+
+    def test_no_prompt_omits_flag(self):
+        cmd = _capture_command(prompt=None)
+        assert "--prompt" not in cmd
+        assert "--carry-initial-prompt" not in cmd
+
+    def test_empty_prompt_omits_flag(self):
+        cmd = _capture_command(prompt="")
+        assert "--prompt" not in cmd
+
+    def test_never_uses_dash_p(self):
+        # -p is whisper's --processors, NOT prompt - regression guard.
+        cmd = _capture_command(prompt="x")
+        assert "-p" not in cmd
+
+
+# ============================================================================
+# resolver precedence
+# ============================================================================
+
+
+def _ns(**kw):
+    defaults = {"whisper_prompt": None, "glossary": None, "language": None, "whisper_model": ""}
+    defaults.update(kw)
+    return argparse.Namespace(**defaults)
+
+
+class TestResolveWhisperPrompt:
+    def test_neither_returns_none(self):
+        assert _resolve_whisper_prompt(_ns()) is None
+
+    def test_raw_prompt_passthrough(self):
+        assert _resolve_whisper_prompt(_ns(whisper_prompt="raw text")) == "raw text"
+
+    def test_whisper_prompt_overrides_glossary(self):
+        with patch("pidcast.workflow.logger") as mock_log:
+            out = _resolve_whisper_prompt(_ns(whisper_prompt="raw", glossary="adtech-ai"))
+        assert out == "raw"
+        mock_log.warning.assert_called_once()
+
+    def test_known_glossary_resolves(self):
+        out = _resolve_whisper_prompt(_ns(glossary="adtech-ai"))
+        assert out and "Sabre" in out
+
+    def test_unknown_glossary_raises_with_available(self):
+        with pytest.raises(ConfigurationError) as exc:
+            _resolve_whisper_prompt(_ns(glossary="does-not-exist"))
+        assert "adtech-ai" in str(exc.value)
+
+    def test_en_model_non_english_warns(self):
+        with patch("pidcast.workflow.logger") as mock_log:
+            _resolve_whisper_prompt(
+                _ns(glossary="adtech-ai", language="uk", whisper_model="ggml-small.en.bin")
+            )
+        mock_log.warning.assert_called_once()
+
+    def test_en_model_english_no_warn(self):
+        with patch("pidcast.workflow.logger") as mock_log:
+            _resolve_whisper_prompt(
+                _ns(glossary="adtech-ai", language="en", whisper_model="ggml-small.en.bin")
+            )
+        mock_log.warning.assert_not_called()
+
+
+# ============================================================================
+# glossary loader
+# ============================================================================
+
+
+class TestLoadGlossaries:
+    def test_seeded_glossary_present(self):
+        g = load_glossaries()
+        assert "adtech-ai" in g
+        assert "Xenoss" in g["adtech-ai"]
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert load_glossaries(tmp_path / "nope.yaml") == {}
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        f = tmp_path / "g.yaml"
+        f.write_text("")
+        assert load_glossaries(f) == {}
+
+    def test_invalid_yaml_returns_empty(self, tmp_path):
+        f = tmp_path / "g.yaml"
+        f.write_text("glossaries: [unclosed")
+        assert load_glossaries(f) == {}
+
+    def test_parses_custom_glossary(self, tmp_path):
+        f = tmp_path / "g.yaml"
+        f.write_text("glossaries:\n  foo: Bar baz qux.\n")
+        g = load_glossaries(f)
+        assert g == {"foo": "Bar baz qux."}


### PR DESCRIPTION
## What

Adds a glossary / initial-prompt lever so whisper.cpp biases decoding toward domain proper nouns and jargon it otherwise mis-transcribes (Sabre, Xenoss, Claude Code, agentic, evals, MCP, ...).

```bash
pidcast interview.mp3 --glossary adtech-ai          # named glossary from config/glossaries.yaml
pidcast interview.mp3 --whisper-prompt "Names: Acme, gRPC."   # raw inline prompt
```

## Why (empirical)

On a real 5-min interview slice, scored against the proper nouns each config got wrong:

| Config | Wall-clock | Fixable terms correct |
|---|---|---|
| `small.en` (no glossary) | 2m30s | 2/5 |
| `medium.en` | 11m57s | 3/5 |
| **`small.en` + `--glossary`** | **3m08s** | **5/5** |

The bottleneck is **vocabulary, not model size** - a glossary on the small model beats a 3.7x-slower bigger model. Verified end-to-end through the pidcast pipeline: 5/5, including two names (Xenoss, Claude Code) that *no* model fixed unaided.

## User-facing impact

Transcripts of niche-vocabulary audio (interviews, ad-tech/AI podcasts) come out with proper nouns spelled correctly instead of needing a manual correction pass - without paying the runtime cost of a larger model.

## How

- `run_whisper_transcription`: new keyword-only `prompt` param emits `--prompt` **plus `--carry-initial-prompt`** so the bias persists across all decode windows, not just the first (critical for long files). Flows through both the one-shot and checkpointed/resume paths via the existing `**self._opts` splat - no provider-layer change.
- `config.load_glossaries()` + `config/glossaries.yaml`; a missing/invalid file is **non-fatal** (transcription keeps working unbiased).
- CLI: `--glossary NAME` and `--whisper-prompt TEXT`. Explicit `--whisper-prompt` wins over `--glossary`; an unknown glossary **fails loudly** with the available names before transcription starts.
- Seeded the `adtech-ai` glossary.

## Tests

- argv-level command construction (`--prompt` present/absent; `-p` is whisper's `--processors`, asserted never used as a guard), resolver precedence, the `.en`+non-English warning, glossary-loader edge cases.
- Full suite: **368 passing**, ruff clean.

## Note on base branch

Stacked on `fix/duplicate-detection-stats-rework` (not `main`): this feature's `prompt` kwarg flows through the checkpoint/resume plumbing introduced there, and both branches edit the same 4 core files. Merge that branch first, then rebase/merge this one.