### PR TITLE
docs: close --vad and pre-commit documentation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ uv run pidcast "URL" --no-analyze
 # Custom front matter tags (overrides auto-inferred source tags)
 uv run pidcast "/path/to/meeting.mp3" --tags meeting,standup,weekly
 
+# Strip silence before decoding to curb whisper hallucinations (needs a Silero VAD model)
+uv run pidcast "URL" --vad
+uv run pidcast "URL" --vad --vad-threshold 0.6   # raise the speech-probability cutoff
+
 # Test settings on a 2-minute slice before committing to a long run
 uv run pidcast "URL" --test-segment
 
@@ -95,6 +99,8 @@ uv run pidcast -P     # list presets
 Available analysis types: `executive_summary` (default), `summary`, `key_points`, `action_items`, `comprehensive`. Every type ends with a **Shareable Brief** — a punchy headline (≤ 15 words) plus a 3–5 sentence quick-take suitable for sending to a friend.
 
 Claude model aliases: `sonnet` (claude-sonnet-4-6, default), `opus` (claude-opus-4-6), `haiku` (claude-haiku-4-5).
+
+**Whisper anti-hallucination:** on the whisper path, `--suppress-nst` is ON by default (suppresses non-speech tokens), and repeated identical lines are collapsed in post-processing. For long files with stretches of silence, add `--vad` to strip silence before decoding — it needs a Silero VAD model pointed at by `WHISPER_VAD_MODEL` in `.env` (no-ops with a warning if none is found; `pidcast doctor` reports its status). Tune the speech-probability cutoff with `--vad-threshold` (default 0.50).
 
 ## 🎙️ Library <a name="library"></a>
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -17,7 +17,7 @@ cd pidcast
 uv sync --group dev          # runtime + dev deps (ruff, pytest)
 cp .env.example .env         # fill in keys
 uv run pidcast setup         # interactive wizard for paths and models
-pre-commit install           # ruff + mermaid validation on commit
+pre-commit install           # framework hooks: ruff + markdownlint (see Plugin-driven automation)
 ```
 
 `pidcast setup` walks through whisper.cpp paths, model selection, and API keys. Run `pidcast doctor` at any time to check the current state of your tooling and env.
@@ -33,6 +33,7 @@ Set in `.env`. See `.env.example` for the up-to-date list.
 | `HUGGINGFACE_TOKEN` | Downloads pyannote diarization model on first use | Required for `--diarize` on the whisper path |
 | `WHISPER_CPP_PATH` | Path to `whisper-cli` binary | Required for local whisper transcription |
 | `WHISPER_MODEL` | Path to a `ggml-*.bin` model file | Required for local whisper transcription |
+| `WHISPER_VAD_MODEL` | Path to a Silero VAD model (`ggml-silero-*.bin`); enables `--vad` to strip silence before decoding | Optional (required only when passing `--vad`) |
 | `FFMPEG_PATH` | Custom ffmpeg location | Optional (defaults to PATH lookup) |
 | `OBSIDIAN_VAULT_PATH` | Target vault root for `--save-to-obsidian` | Optional |
 
@@ -125,6 +126,14 @@ This repo opts into several Claude Code plugins. Their config lives in `.claude-
 
 - `semver.json` — auto bumps `pyproject.toml` version on feature/fix commits (excludes `*.md`, `docs/**`)
 - `kb-grooming.json` — documentation health check scope
-- pre-commit hook in `.githooks/pre-commit` — ruff, PlantUML, and Mermaid validation
 
 The session entry points (`/semver:setup`, `/kb-grooming:kb-groom`, `/playbook:playbook-browse`) are usable from Claude Code but not from regular shells.
+
+### Commit-time validation
+
+Two independent hook mechanisms run on commit — keep both in mind:
+
+- **Native git hook** — `.githooks/pre-commit`, wired in via `core.hooksPath = .githooks` (already set in the repo). Runs `ruff check` + `ruff format --check` on staged `*.py`, then PlantUML URL-sync and Mermaid syntax validation on staged `*.md`. This is the authoritative gate and runs even without the pre-commit framework installed.
+- **pre-commit framework** — `.pre-commit-config.yaml`, activated by running `pre-commit install` (see First-time setup). Runs `ruff` (with `--fix`), `ruff-format`, and `markdownlint --fix`. Complements the native hook; mainly autofixes formatting.
+
+Don't bypass either with `--no-verify` — fix the underlying issue.


### PR DESCRIPTION
## Summary

Fixes two real documentation gaps surfaced by a `/kb-grooming:kb-groom` pass. Docs-only; no version bump (`*.md` / `docs/**` excluded by semver config).

## Gap 1 — `--vad` was undiscoverable

The whisper `--vad` anti-hallucination flag and its `WHISPER_VAD_MODEL` env var were documented **only** in `CLAUDE.md`, so users reading the README or dev guide had no path to silence-stripping.

- **README** — added `--vad` / `--vad-threshold` to Usage examples, plus a "Whisper anti-hallucination" note covering `--suppress-nst` (on by default), `--vad`, and the `WHISPER_VAD_MODEL` requirement (with `pidcast doctor` status hint).
- **dev guide** — added a `WHISPER_VAD_MODEL` row to the environment-variables table.

**User-facing impact:** README readers can now find and tune `--vad`; contributors know which env var enables it.

## Gap 2 — self-contradicting pre-commit description

The dev guide described commit-time validation two different ways ("ruff + mermaid" in First-time setup vs. "ruff, PlantUML, and Mermaid" in Plugin-driven automation) and conflated two distinct mechanisms.

Audited the actual hooks and reconciled the docs against reality:

- **Native git hook** — `.githooks/pre-commit` (wired via `core.hooksPath = .githooks`): ruff on `*.py`, then PlantUML URL-sync + Mermaid validation on `*.md`. The authoritative gate.
- **pre-commit framework** — `.pre-commit-config.yaml` (via `pre-commit install`): ruff `--fix`, ruff-format, markdownlint `--fix`.

Added a dedicated "Commit-time validation" subsection explaining both; corrected the First-time setup comment.

**User-facing impact:** new contributors get an accurate, non-contradictory picture of what runs on commit.

## Verification

- `git diff`: +17 / -2 across `README.md` and `docs/development-guide.md`.
- The commit's own `.githooks/pre-commit` ran on these `.md` files and passed (PlantUML in sync, Mermaid clean).