### PR TITLE
docs: sync storage paths to XDG data dir after refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ uv run pidcast -L     # list analysis types
 uv run pidcast -M     # list LLM models
 uv run pidcast -W     # list Whisper models
 uv run pidcast -P     # list presets
+uv run pidcast paths  # show where transcripts, audio, logs, and run history live
 ```
+
+By default, transcripts, kept audio, logs, and the run history live under the XDG data dir (`~/.local/share/pidcast/`, or `$XDG_DATA_HOME/pidcast/`) — not in the repo. Override the whole tree with `PIDCAST_DATA_DIR`, set a fixed transcript directory with `--output-dir` or the `output_dir` key in `~/.config/pidcast/config.yaml`, and run `pidcast paths` to see what resolves.
 
 Available analysis types: `executive_summary` (default), `summary`, `key_points`, `action_items`, `comprehensive`. Every type ends with a **Shareable Brief** — a punchy headline (≤ 15 words) plus a 3–5 sentence quick-take suitable for sending to a friend.
 
@@ -150,7 +153,7 @@ uv run pidcast-eval --compare groq,claude --transcript-file transcript.txt --tit
 uv run pidcast-eval --run-matrix           # all prompt × model × reference combos
 ```
 
-Reports land in `data/evals/comparisons/`. See [docs/development-guide.md](docs/development-guide.md#provider-comparison-evals) for the full eval matrix flags.
+Reports land under the data dir, in `evals/comparisons/` (run `pidcast paths` to resolve it; default `~/.local/share/pidcast/evals/comparisons/`). See [docs/development-guide.md](docs/development-guide.md#provider-comparison-evals) for the full eval matrix flags.
 
 ## 📚 Documentation <a name="documentation"></a>
 

--- a/docs/adr/0001-transcription-providers.md
+++ b/docs/adr/0001-transcription-providers.md
@@ -23,7 +23,7 @@ Diarization follows the same pluggability: whisper uses pyannote post-hoc, Eleve
 
 - New users can be productive in under 5 minutes with just an ElevenLabs API key. Local-first users keep their existing flow.
 - Workflow code is provider-agnostic. Future providers (Deepgram, AssemblyAI) plug into `providers/` without touching `workflow.py`.
-- The eval matrix in `data/evals/` can compare providers head-to-head on the same audio.
+- The eval matrix (output under the data dir's `evals/`; run `pidcast paths`) can compare providers head-to-head on the same audio.
 
 **Negative:**
 

--- a/docs/adr/0002-llm-providers.md
+++ b/docs/adr/0002-llm-providers.md
@@ -6,7 +6,7 @@
 
 Analysis (summarization, key points, action items, comprehensive briefing) was Groq-only since the project's first release. Groq is fast and cheap, but two problems pushed for a second option:
 
-1. **Quality ceiling.** On long, dense audio (technical talks, multi-speaker debates), Groq's Llama 3.x outputs lose nuance compared to frontier models. A handful of evals (`data/evals/comparisons/`) confirmed the gap on accuracy and completeness scores.
+1. **Quality ceiling.** On long, dense audio (technical talks, multi-speaker debates), Groq's Llama 3.x outputs lose nuance compared to frontier models. A handful of evals (output under the data dir's `evals/comparisons/`; run `pidcast paths`) confirmed the gap on accuracy and completeness scores.
 2. **No use of local Claude Code.** Many users already have an authenticated Claude Code CLI installed locally for other workflows. Reusing that subscription for pidcast analysis sidesteps yet another API key.
 
 ## Decision

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ This document maps the runtime data flow and the module boundaries. Start here w
 %%{init: {'theme':'base','flowchart':{'curve':'basis','nodeSpacing':60,'rankSpacing':80}}}%%
 flowchart TD
     accTitle: pidcast single-shot transcription and analysis pipeline
-    accDescr: A URL or file is resolved to audio, normalized to WAV, transcribed by the chosen provider, optionally diarized, optionally analyzed by a Groq or Claude model, then written as Markdown to disk or an Obsidian vault. Run history and stats are persisted.
+    accDescr: A URL or file is resolved to audio, normalized to WAV, transcribed by the chosen provider, optionally diarized, optionally analyzed by a Groq or Claude model, then written as Markdown to the XDG data dir or an Obsidian vault. Run history is persisted to a unified runs.json store.
 
     User([User]) -->|pidcast URL_OR_PATH| CLI{{cli.py}}
     CLI --> Workflow{{workflow.py}}
@@ -60,15 +60,14 @@ flowchart TD
 
     Markdown --> Out{--save-to-obsidian?}
     Out -->|yes| Vault[(Obsidian vault)]
-    Out -->|no| Disk[(data/transcripts/)]
+    Out -->|no| Disk[(XDG data dir<br/>transcripts/)]
 
-    Markdown --> Stats[(transcription_stats.json)]
-    Markdown --> History[(history.py)]
+    Markdown --> History[(state/runs.json<br/>unified run history)]
 
     classDef storage fill:#ecfdf5,stroke:#16a34a,color:#064e3b;
     classDef external fill:#fef3c7,stroke:#d97706,color:#78350f;
     classDef orchestrator fill:#ede9fe,stroke:#7c3aed,color:#4c1d95;
-    class Vault,Disk,Stats,History storage;
+    class Vault,Disk,History storage;
     class Whisper,EL,Pyannote,Groq,Claude external;
     class CLI,Workflow orchestrator;
 
@@ -98,7 +97,7 @@ flowchart LR
     Sync --> Workflow{{workflow.py}}
 
     User -->|pidcast lib digest| Digest(digest.py)
-    Digest --> Hist[(processing history)]
+    Digest --> Hist[(state/runs.json<br/>run history)]
 
     classDef storage fill:#ecfdf5,stroke:#16a34a,color:#064e3b;
     classDef external fill:#fef3c7,stroke:#d97706,color:#78350f;

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -98,7 +98,7 @@ logs, run history, and eval output) live in the XDG data dir. Run `pidcast paths
 - **LLM responses:** all analysis prompts return JSON with `analysis` and `contextual_tags` fields. Add fields via `config/prompts.yaml`, not via prompt-string surgery in code.
 - **Chunking threshold:** 120 000 characters triggers semantic chunking with synthesis. Threshold lives in `config.py`.
 - **Filenames:** smart-prefixed `YYYY-MM-DD_Title.md`. Logic in `utils.py`.
-- **Transcripts canonical location:** the XDG data dir, `$XDG_DATA_HOME/pidcast/transcripts/` (default `~/.local/share/pidcast/`; override with `PIDCAST_DATA_DIR`; run `pidcast paths`). Audio (`audio/`), logs (`logs/`), and the unified run history (`state/runs.json`) live alongside it; config and the podcast library stay in `~/.config/pidcast/`. The repo gitignores stray `YYYY-MM-DD_*.md` files at the root.
+- **Transcripts canonical location:** the XDG data dir, `$XDG_DATA_HOME/pidcast/transcripts/` (default `~/.local/share/pidcast/transcripts/`; override the tree with `PIDCAST_DATA_DIR`; run `pidcast paths`). Audio (`audio/`), logs (`logs/`), and the unified run history (`state/runs.json`) live alongside it; config and the podcast library stay in `~/.config/pidcast/`. The repo gitignores stray `YYYY-MM-DD_*.md` files at the root.
 
 ## Provider comparison evals
 


### PR DESCRIPTION
## What & why

PR #27 moved all generated data (transcripts, audio, logs, run history, eval output) out of the repo's `data/` dir into the XDG data dir, removed the repo `data/` dir, and unified the two run-history stores into a single `state/runs.json`. A few **living docs** still described the old repo-local layout. This closes that drift.

Found via a fresh-context audit of every doc file against what actually shipped.

## Changes

- **README.md** — fixed the stale `data/evals/comparisons/` path; added a note in Usage on where transcripts/audio/logs/history land by default, the `PIDCAST_DATA_DIR` override, and the new `pidcast paths` discovery command (was undocumented in the README).
- **docs/architecture.md** — updated the data-flow and library-subsystem diagrams: storage now shows the XDG transcripts dir and the unified `state/runs.json` store (was `data/transcripts/` and `transcription_stats.json`, which no longer exist).
- **docs/adr/0001 & 0002** — repointed `data/evals/` references to the data dir's `evals/`.
- **docs/development-guide.md** — named the `transcripts/` subdir in the default-path note (minor precision fix; the section was otherwise already updated in #27).

## User-facing impact

Docs now point new and existing users at the **real** storage locations (and at `pidcast paths` to resolve them), so nobody goes hunting for a repo `data/` dir that was removed in #27.

## Deliberately left untouched

- **CLAUDE.md** — the "`data/transcripts/` may still hold pre-migration files" line is an intentional caveat about legacy files, not stale docs.
- **docs/ideation/** and **docs/ultrathink/** — point-in-time planning artifacts (PRDs, specs) that describe original design intent at time of writing. Rewriting them would falsify the historical record, same as editing a merged ADR's Context.

Docs-only, no version bump, no code touched.
