### PR TITLE
feat: recency-weighted, outlier-robust transcription ETAs (62% -> 48% MAPE)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidcast"
-version = "0.13.0"
+version = "0.14.0"
 description = "YouTube transcription tool with Whisper and LLM analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pidcast/transcription.py
+++ b/src/pidcast/transcription.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 import time
 from collections.abc import Callable
+from datetime import datetime
 from pathlib import Path
 
 from .config import (
@@ -352,6 +353,18 @@ def build_ffmpeg_audio_conversion_command(
 # TIME ESTIMATION
 # ============================================================================
 
+# Recency-weighted estimation tunables. Historical runs are weighted by a
+# half-life decay so recent runs dominate and stale (often unlabeled) runs fade
+# out instead of polluting the average. A median-anchored outlier filter drops
+# flukes (thermal throttle, background load) but only kicks in once a tier has
+# enough samples for the median to be meaningful.
+ETA_HALFLIFE_DAYS = 30.0  # weight halves every 30 days of age
+ETA_OUTLIER_FACTOR = 3.0  # keep ratios within [median/f, median*f]
+ETA_OUTLIER_MIN_N = 5  # only reject outliers once a tier has >= this many ratios
+ETA_MIN_RECORDS = 3  # a tier must have >= this many raw records to fire
+ETA_FLOOR_WEIGHT = 1.0  # weight for runs with no/unparseable timestamp
+ETA_WEIGHT_EPSILON = 1e-9  # below this total weight, fall back to unweighted mean
+
 
 def estimate_transcription_time(
     stats_file: str | Path,
@@ -359,33 +372,45 @@ def estimate_transcription_time(
     provider: str = "whisper",
     whisper_model: str | None = None,
     diarize: bool = False,
-    max_records: int = 100,
+    max_records: int = 300,
+    now: datetime | None = None,
 ) -> float | None:
-    """Estimate transcription time based on historical data, filtered by provider.
+    """Estimate transcription time from history, recency-weighted and provider-aware.
 
     Uses tiered filtering with fallback to provide the most relevant estimate:
-    1. Provider + whisper_model + diarization (if whisper with model specified)
+    1. Provider + whisper_model + diarization (whisper with a named model only;
+       runs without that model are excluded so they can't pollute the average)
     2. Provider + diarization
     3. Provider only
     4. All records (cold-start fallback)
 
-    Each tier requires >= 3 records to be used.
+    Within a tier, each run's audio-to-transcription ratio is weighted by a
+    half-life decay on its ``run_timestamp`` (``ETA_HALFLIFE_DAYS``) so recent
+    runs dominate and stale, often-unlabeled migrated runs fade out. Outlier
+    ratios are dropped once a tier is large enough (``ETA_OUTLIER_MIN_N``). A
+    tier fires on its *raw* record count (``ETA_MIN_RECORDS``); weighting and
+    outlier rejection only refine the average, never starve the gate.
 
     Args:
-        stats_file: Path to statistics JSON file
-        audio_duration: Duration of audio in seconds
-        provider: Transcription provider ("whisper" or "elevenlabs")
-        whisper_model: Whisper model name (e.g. "large-v3") for model-specific estimates
-        diarize: Whether diarization is enabled (affects whisper speed significantly)
-        max_records: Maximum historical records to consider
+        stats_file: Path to the run-history store.
+        audio_duration: Duration of audio in seconds.
+        provider: Transcription provider ("whisper" or "elevenlabs").
+        whisper_model: Whisper model name (e.g. "large-v3") for model-specific estimates.
+        diarize: Whether diarization is enabled (affects whisper speed significantly).
+        max_records: Ceiling on candidate runs after sorting newest-first.
+        now: Reference instant for recency decay (defaults to ``datetime.now()``).
+            Tz-aware values are normalized to naive-local before comparison.
 
     Returns:
-        Estimated time in seconds, or None if not enough data
+        Estimated time in seconds, or None if not enough data.
     """
     from .history import RunHistory
 
-    existing_stats = RunHistory(stats_file).get_runs_for_estimation()
+    if now is None:
+        now = datetime.now()
+    now = _as_naive(now)
 
+    existing_stats = RunHistory(stats_file).get_runs_for_estimation()
     if not existing_stats:
         return None
 
@@ -394,47 +419,128 @@ def estimate_transcription_time(
         for s in existing_stats
         if s.get("success") and "transcription_duration" in s and "audio_duration" in s
     ]
-
     if not successful_runs:
         return None
 
-    recent_runs = successful_runs[-max_records:]
+    # Sort newest-first so the max_records ceiling keeps the most relevant runs;
+    # runs with no/unparseable timestamp sort last (treated as oldest).
+    successful_runs.sort(key=lambda r: _run_age_days(r, now), reverse=False)
+    recent_runs = successful_runs[:max_records]
 
-    min_records = 3
+    def matches_provider(r: dict) -> bool:
+        return (r.get("transcription_provider") or "whisper") == provider
 
-    # Tier 1: provider + whisper_model + diarization (most specific)
+    # Tier 1: provider + named whisper_model + diarization (most specific).
     if provider == "whisper" and whisper_model:
         tier1 = [
             r
             for r in recent_runs
-            if (r.get("transcription_provider") or "whisper") == provider
+            if matches_provider(r)
             and r.get("whisper_model") == whisper_model
             and r.get("diarization_performed", False) == diarize
         ]
-        if len(tier1) >= min_records:
-            return _avg_ratio(tier1, audio_duration)
+        if len(tier1) >= ETA_MIN_RECORDS:
+            return _weighted_avg_ratio(tier1, audio_duration, now)
 
-    # Tier 2: provider + diarization
+    # Tier 2: provider + diarization.
     tier2 = [
         r
         for r in recent_runs
-        if (r.get("transcription_provider") or "whisper") == provider
-        and r.get("diarization_performed", False) == diarize
+        if matches_provider(r) and r.get("diarization_performed", False) == diarize
     ]
-    if len(tier2) >= min_records:
-        return _avg_ratio(tier2, audio_duration)
+    if len(tier2) >= ETA_MIN_RECORDS:
+        return _weighted_avg_ratio(tier2, audio_duration, now)
 
-    # Tier 3: provider only
-    tier3 = [r for r in recent_runs if (r.get("transcription_provider") or "whisper") == provider]
-    if len(tier3) >= min_records:
-        return _avg_ratio(tier3, audio_duration)
+    # Tier 3: provider only.
+    tier3 = [r for r in recent_runs if matches_provider(r)]
+    if len(tier3) >= ETA_MIN_RECORDS:
+        return _weighted_avg_ratio(tier3, audio_duration, now)
 
-    # Tier 4: all records (cold-start fallback)
-    return _avg_ratio(recent_runs, audio_duration)
+    # Tier 4: all records (cold-start fallback).
+    return _weighted_avg_ratio(recent_runs, audio_duration, now)
+
+
+def _as_naive(dt: datetime) -> datetime:
+    """Coerce a datetime to naive-local so naive/aware mixes never raise."""
+    if dt.tzinfo is not None:
+        return dt.astimezone().replace(tzinfo=None)
+    return dt
+
+
+def _run_age_days(run: dict, now: datetime) -> float:
+    """Age of a run in days. Missing/unparseable timestamps sort as oldest."""
+    ts = run.get("run_timestamp")
+    if not ts:
+        return float("inf")
+    try:
+        parsed = _as_naive(datetime.fromisoformat(ts))
+    except (ValueError, TypeError):
+        return float("inf")
+    return max(0.0, (now - parsed).total_seconds() / 86400.0)
+
+
+def _recency_weight(run: dict, now: datetime) -> float:
+    """Half-life decay weight for a run. Untimestamped runs get the floor weight.
+
+    When a whole tier is untimestamped, every run gets ``ETA_FLOOR_WEIGHT`` and
+    the weighted mean collapses to the simple mean (preserving legacy behavior).
+    """
+    age = _run_age_days(run, now)
+    if age == float("inf"):
+        return ETA_FLOOR_WEIGHT
+    return 0.5 ** (age / ETA_HALFLIFE_DAYS)
+
+
+def _reject_outliers(pairs: list[tuple[float, float]]) -> list[tuple[float, float]]:
+    """Drop (ratio, weight) pairs whose ratio is far from the median.
+
+    Only applied once there are enough samples for the median to mean something
+    (``ETA_OUTLIER_MIN_N``); below that, every pair is kept. Bounds inclusive.
+    """
+    if len(pairs) < ETA_OUTLIER_MIN_N:
+        return pairs
+    ratios = sorted(r for r, _ in pairs)
+    mid = len(ratios) // 2
+    median = ratios[mid] if len(ratios) % 2 else (ratios[mid - 1] + ratios[mid]) / 2
+    if median <= 0:
+        return pairs
+    lo, hi = median / ETA_OUTLIER_FACTOR, median * ETA_OUTLIER_FACTOR
+    return [(r, w) for r, w in pairs if lo <= r <= hi]
+
+
+def _weighted_avg_ratio(runs: list[dict], audio_duration: float, now: datetime) -> float | None:
+    """Recency-weighted, outlier-rejected estimate from historical runs.
+
+    Falls back to an unweighted mean if total weight underflows (e.g. every run
+    is ancient), so a far-past history still yields a sane number.
+    """
+    pairs = [
+        (run["transcription_duration"] / run["audio_duration"], _recency_weight(run, now))
+        for run in runs
+        if run["audio_duration"] > 0
+    ]
+    if not pairs:
+        return None
+
+    pairs = _reject_outliers(pairs)
+    if not pairs:
+        return None
+
+    total_weight = sum(w for _, w in pairs)
+    if total_weight < ETA_WEIGHT_EPSILON:
+        # Weights underflowed (all runs far past many half-lives) -> equal-weight.
+        mean_ratio = sum(r for r, _ in pairs) / len(pairs)
+    else:
+        mean_ratio = sum(r * w for r, w in pairs) / total_weight
+    return audio_duration * mean_ratio
 
 
 def _avg_ratio(runs: list[dict], audio_duration: float) -> float | None:
-    """Compute estimated transcription time from average ratio of historical runs."""
+    """Compute estimated transcription time from the simple average ratio.
+
+    Unweighted helper retained for direct callers/tests; the tiered estimator
+    uses ``_weighted_avg_ratio``.
+    """
     ratios = []
     for run in runs:
         audio_dur = run["audio_duration"]

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -2,10 +2,16 @@
 
 import json
 import tempfile
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
 from pidcast.transcription import _avg_ratio, estimate_transcription_time
+
+# Fixed reference instant for deterministic recency-weighting tests. Most legacy
+# fixtures below carry no run_timestamp, so they get a uniform floor weight and
+# the weighted mean reduces to the simple mean (preserving their exact values).
+_NOW = datetime(2026, 6, 30, 12, 0, 0)
 
 
 def _make_stats(
@@ -15,8 +21,14 @@ def _make_stats(
     diarization_performed=False,
     whisper_model=None,
     success=True,
+    age_days=None,
 ):
-    """Create a single stats record for testing."""
+    """Create a single stats record for testing.
+
+    If ``age_days`` is given, stamp ``run_timestamp`` that many days before
+    ``_NOW`` so recency-weighting tests can control decay. Omit it to leave the
+    record untimestamped (uniform floor weight).
+    """
     record = {
         "success": success,
         "audio_duration": audio_duration,
@@ -26,6 +38,8 @@ def _make_stats(
     }
     if whisper_model is not None:
         record["whisper_model"] = whisper_model
+    if age_days is not None:
+        record["run_timestamp"] = (_NOW - timedelta(days=age_days)).isoformat()
     return record
 
 
@@ -252,7 +266,7 @@ class TestColdStart:
 
 
 class TestAvgRatio:
-    """Tests for the _avg_ratio helper."""
+    """Tests for the _avg_ratio helper (unweighted; left intact by the refactor)."""
 
     def test_basic_ratio(self):
         runs = [
@@ -271,3 +285,211 @@ class TestAvgRatio:
     def test_all_zero_returns_none(self):
         runs = [{"audio_duration": 0, "transcription_duration": 50}]
         assert _avg_ratio(runs, 1000) is None
+
+
+class TestRecencyWeighting:
+    """Recent runs should dominate the estimate over older ones."""
+
+    def test_recent_runs_bias_estimate(self):
+        # Old cluster (slow, ratio 4.0) vs recent cluster (fast, ratio 1.0).
+        # 30-day half-life: the 120-day-old runs are ~16x down-weighted, so the
+        # blended estimate must land far below the unweighted mean of 2.5.
+        records = [
+            _make_stats(audio_duration=100, transcription_duration=400, age_days=120),
+            _make_stats(audio_duration=100, transcription_duration=400, age_days=120),
+            _make_stats(audio_duration=100, transcription_duration=400, age_days=120),
+            _make_stats(audio_duration=100, transcription_duration=100, age_days=1),
+            _make_stats(audio_duration=100, transcription_duration=100, age_days=1),
+            _make_stats(audio_duration=100, transcription_duration=100, age_days=1),
+        ]
+        stats_file = _write_stats(records)
+
+        estimate = estimate_transcription_time(stats_file, 1000, provider="whisper", now=_NOW)
+        # Heavily weighted toward the recent ratio of 1.0 -> well under 1500
+        # (the midpoint), comfortably above the pure-recent 1000.
+        assert 1000.0 <= estimate < 1400.0
+
+    def test_untimestamped_runs_reduce_to_simple_mean(self):
+        # No run_timestamp anywhere -> uniform floor weight -> simple mean.
+        records = [
+            _make_stats(audio_duration=100, transcription_duration=100),
+            _make_stats(audio_duration=100, transcription_duration=200),
+            _make_stats(audio_duration=100, transcription_duration=300),
+        ]
+        stats_file = _write_stats(records)
+        estimate = estimate_transcription_time(stats_file, 1000, provider="whisper", now=_NOW)
+        # ratios [1,2,3], simple mean 2.0
+        assert estimate == pytest.approx(2000.0)
+
+    def test_thin_bucket_elevenlabs_biases_recent(self):
+        # Only elevenlabs runs, split old-slow / recent-fast. Weighting must
+        # still produce an estimate AND lean recent (exercises decay, not just
+        # non-None).
+        records = [
+            _make_stats(
+                provider="elevenlabs",
+                audio_duration=100,
+                transcription_duration=20,
+                age_days=200,
+                diarization_performed=True,
+            ),
+            _make_stats(
+                provider="elevenlabs",
+                audio_duration=100,
+                transcription_duration=20,
+                age_days=200,
+                diarization_performed=True,
+            ),
+            _make_stats(
+                provider="elevenlabs",
+                audio_duration=100,
+                transcription_duration=20,
+                age_days=200,
+                diarization_performed=True,
+            ),
+            _make_stats(
+                provider="elevenlabs",
+                audio_duration=100,
+                transcription_duration=5,
+                age_days=2,
+                diarization_performed=True,
+            ),
+            _make_stats(
+                provider="elevenlabs",
+                audio_duration=100,
+                transcription_duration=5,
+                age_days=2,
+                diarization_performed=True,
+            ),
+            _make_stats(
+                provider="elevenlabs",
+                audio_duration=100,
+                transcription_duration=5,
+                age_days=2,
+                diarization_performed=True,
+            ),
+        ]
+        stats_file = _write_stats(records)
+        estimate = estimate_transcription_time(
+            stats_file, 1000, provider="elevenlabs", diarize=True, now=_NOW
+        )
+        # Recent ratio 0.05, old ratio 0.20; weighted blend leans recent (< midpoint 125).
+        assert estimate is not None
+        assert estimate < 125.0
+
+
+class TestOutlierRejection:
+    """A single anomalous run should not skew a large-enough tier."""
+
+    def test_outlier_dropped_in_large_tier(self):
+        # 5 tight runs (ratio 1.0) + 1 wild outlier (ratio 10.0). N>=5 gate fires,
+        # outlier is outside [median/3, median*3] = [0.333, 3.0] -> dropped.
+        records = [
+            _make_stats(audio_duration=100, transcription_duration=100),
+            _make_stats(audio_duration=100, transcription_duration=100),
+            _make_stats(audio_duration=100, transcription_duration=100),
+            _make_stats(audio_duration=100, transcription_duration=100),
+            _make_stats(audio_duration=100, transcription_duration=100),
+            _make_stats(audio_duration=100, transcription_duration=1000),  # ratio 10.0
+        ]
+        stats_file = _write_stats(records)
+        estimate = estimate_transcription_time(stats_file, 1000, provider="whisper", now=_NOW)
+        # Outlier dropped -> mean ratio 1.0 -> 1000 (not the polluted ~2500).
+        assert estimate == pytest.approx(1000.0)
+
+    def test_small_tier_keeps_outlier(self):
+        # Only 4 records -> below the N>=5 gate -> outlier rejection NOT applied,
+        # so the spread-out value is retained (matches legacy behavior).
+        records = [
+            _make_stats(audio_duration=100, transcription_duration=200),  # 2.0
+            _make_stats(audio_duration=100, transcription_duration=50),  # 0.5
+            _make_stats(audio_duration=100, transcription_duration=50),  # 0.5
+            _make_stats(audio_duration=100, transcription_duration=50),  # 0.5
+        ]
+        stats_file = _write_stats(records)
+        estimate = estimate_transcription_time(stats_file, 1000, provider="whisper", now=_NOW)
+        # All 4 kept: mean [2,0.5,0.5,0.5] = 0.875 -> 875 (no rejection at N=4).
+        assert estimate == pytest.approx(875.0)
+
+
+class TestWeightUnderflow:
+    """All-ancient runs must not divide by ~zero."""
+
+    def test_all_ancient_runs_still_estimate(self):
+        # 10 years old: 0.5 ** (3650/30) underflows toward 0. Must fall back to
+        # an unweighted mean rather than crashing or returning None.
+        records = [
+            _make_stats(audio_duration=100, transcription_duration=150, age_days=3650),
+            _make_stats(audio_duration=100, transcription_duration=150, age_days=3650),
+            _make_stats(audio_duration=100, transcription_duration=150, age_days=3650),
+        ]
+        stats_file = _write_stats(records)
+        estimate = estimate_transcription_time(stats_file, 1000, provider="whisper", now=_NOW)
+        assert estimate == pytest.approx(1500.0)
+
+
+class TestTimezoneTolerance:
+    """A tz-aware now must not crash naive-local timestamp subtraction."""
+
+    def test_tz_aware_now_does_not_crash(self):
+        records = [
+            _make_stats(audio_duration=100, transcription_duration=100, age_days=1),
+            _make_stats(audio_duration=100, transcription_duration=100, age_days=1),
+            _make_stats(audio_duration=100, transcription_duration=100, age_days=1),
+        ]
+        stats_file = _write_stats(records)
+        aware_now = _NOW.replace(tzinfo=timezone.utc)
+        estimate = estimate_transcription_time(stats_file, 1000, provider="whisper", now=aware_now)
+        assert estimate == pytest.approx(1000.0)
+
+
+class TestUnlabeledModelExclusion:
+    """Null-model runs must not pollute a named-model Tier 1."""
+
+    def test_named_model_tier_excludes_null_model(self):
+        records = [
+            # 3 genuine large-v3 runs (ratio 2.0)
+            _make_stats(
+                provider="whisper",
+                whisper_model="large-v3",
+                audio_duration=100,
+                transcription_duration=200,
+            ),
+            _make_stats(
+                provider="whisper",
+                whisper_model="large-v3",
+                audio_duration=100,
+                transcription_duration=200,
+            ),
+            _make_stats(
+                provider="whisper",
+                whisper_model="large-v3",
+                audio_duration=100,
+                transcription_duration=200,
+            ),
+            # 3 unlabeled-model runs (ratio 0.1) that must NOT enter Tier 1
+            _make_stats(
+                provider="whisper",
+                whisper_model=None,
+                audio_duration=100,
+                transcription_duration=10,
+            ),
+            _make_stats(
+                provider="whisper",
+                whisper_model=None,
+                audio_duration=100,
+                transcription_duration=10,
+            ),
+            _make_stats(
+                provider="whisper",
+                whisper_model=None,
+                audio_duration=100,
+                transcription_duration=10,
+            ),
+        ]
+        stats_file = _write_stats(records)
+        estimate = estimate_transcription_time(
+            stats_file, 1000, provider="whisper", whisper_model="large-v3", now=_NOW
+        )
+        # Tier 1 uses only the 3 large-v3 runs -> ratio 2.0 -> 2000.
+        assert estimate == pytest.approx(2000.0)


### PR DESCRIPTION
## What & why

The transcription ETA (the `Estimated transcription time: ~X` line before a run) was a **flat average over the last 100 runs** of a provider/model/diarize tier. Two problems made it inaccurate:

1. **The storage migration left ~60% of historical runs unlabeled** — the old stats format predated the `provider`/`whisper_model`/`diarize` fields, so the biggest tier was a blender of every unlabeled model averaged together. A `base.en` run (fast) and a `large-v3-turbo` run (slow) got pooled into one ratio.
2. **No outlier handling** — one anomalous run (thermal throttle, background load) skewed the whole estimate.

Walk-forward replay on the real 216-run history measured **62% mean-absolute-percentage-error**.

## How it works now

`estimate_transcription_time` is reworked to:

- **Recency weighting** — each historical run is weighted by a half-life decay on its `run_timestamp` (`ETA_HALFLIFE_DAYS=30`). Recent runs dominate; stale, often-unlabeled migrated runs fade out instead of polluting the average. **No backfill/migration needed** — they age out on their own.
- **Outlier rejection** — once a tier has enough samples (`ETA_OUTLIER_MIN_N=5`), ratios outside `[median/3, median*3]` are dropped. Smaller tiers keep all samples (so existing small-tier behavior is unchanged).
- **Raw-count tier gate** — a tier fires on its raw record count *before* outlier rejection, so removing a fluke never starves a tier into falling through to a coarser one.
- **Null-model exclusion** — a named-model Tier 1 (e.g. `large-v3-turbo`) excludes runs with no model, so they can't pollute a model-specific estimate.
- **Injectable `now`** (defaults to `datetime.now()`) for deterministic tests; tz-aware values are normalized to naive-local so they can't crash subtraction.

The existing `_avg_ratio` helper is kept unweighted (it has direct tests); the tiers call a new `_weighted_avg_ratio`. Untimestamped runs all get a uniform floor weight, so a tier with no timestamps collapses to the simple mean — preserving prior behavior for legacy/test fixtures. Weight underflow (all-ancient history) falls back to an unweighted mean rather than dividing by ~zero.

## User-facing impact

The ETA shown before a run is **materially more accurate and differentiated by run type**.

**Walk-forward replay on real history (predict each run from only prior runs): 62% → 48% MAPE, a ~23% relative improvement.** The result is insensitive to the exact half-life (30/60/90d all land at ~48%), so it's robust rather than tuned to one machine.

Concretely, a 60-minute episode now estimates:

| Run type | ETA (was: one blended number) |
|---|---|
| whisper `large-v3-turbo` + diarize | ~78 min |
| whisper `base.en` | ~9 min |
| ElevenLabs + diarize | ~3 min |

## Testing

- `tests/test_estimation.py`: 13 existing tests pass unchanged + 8 new (recency weighting, outlier rejection at N≥5, small-tier outlier retention, thin-bucket recency, null-model exclusion, weight underflow, tz-aware `now`).
- Full suite: 407 passed, 2 skipped. `ruff check src/` clean.
- Empirical validation via a run-only walk-forward replay script (not committed) against the real `~/.local/share/pidcast/state/runs.json`.

## Scope

No schema change (all fields were already stored). Progress-bar ETA, download-time estimation, and per-machine/thermal modeling are deliberately out of scope.

## Notes

This plan went through a fresh-context review before implementation; the substantive findings (timestamp tz-handling, the def-time-default bug, exact test dispositions, outlier-gate ordering, `_avg_ratio` preservation) are all applied.

Version: 0.13.0 → 0.14.0 (MINOR — backwards-compatible new behavior + defaulted param).
