### PR TITLE
fix: report true cumulative transcription time across resume legs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidcast"
-version = "0.14.0"
+version = "0.14.1"
 description = "YouTube transcription tool with Whisper and LLM analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pidcast/checkpoint.py
+++ b/src/pidcast/checkpoint.py
@@ -97,6 +97,13 @@ class PhaseState:
     # Transcription-only; advisory mirror of the JSONL tail.
     last_offset_ms: int = 0
     segment_count: int = 0
+    # Transcription-only: cumulative active compute seconds across all resume
+    # legs. Each leg adds its own wall-clock delta; paused/idle time between
+    # sessions is never counted (only time spent actually transcribing). Lets a
+    # multi-session run report its TRUE total transcription time rather than just
+    # the final leg, so the estimate-vs-actual line and the ETA training data
+    # stay honest. Defaults to 0.0 so pre-upgrade manifests load unchanged.
+    elapsed_seconds: float = 0.0
     # Diarization-only.
     requested: bool = False
     speaker_count: int | None = None
@@ -204,6 +211,18 @@ class JobManifest:
         if not segments:
             return 0
         return int(segments[-1].get("to_ms", 0))
+
+    def add_transcription_elapsed(self, leg_seconds: float) -> float:
+        """Accumulate one transcription leg's compute time and persist.
+
+        Called once per session with that session's active transcription
+        wall-clock. Returns the new cumulative total across all legs so the
+        caller can report the true end-to-end transcription time of a job that
+        spanned multiple ``pidcast resume`` invocations.
+        """
+        self.transcription.elapsed_seconds += max(0.0, leg_seconds)
+        self.save()
+        return self.transcription.elapsed_seconds
 
 
 def find_resumable_jobs() -> list[JobManifest]:

--- a/src/pidcast/providers/whisper_provider.py
+++ b/src/pidcast/providers/whisper_provider.py
@@ -97,14 +97,19 @@ class WhisperTranscriptionProvider:
                 "Required for speaker diarization with Whisper."
             )
 
-        start_time = time.time()
         json_file = Path(f"{temp_output}.json")
 
         if self._checkpoint is not None:
             # Resumable path: stream segments into the manifest's JSONL, resume
-            # from the persisted offset, then materialize the merged JSON.
+            # from the persisted offset, then materialize the merged JSON. The
+            # leg's compute time is accumulated into the manifest inside
+            # _transcribe_checkpointed; report the CUMULATIVE total across all
+            # resume sessions so a multi-session run's duration reflects the true
+            # end-to-end transcription time (not just this leg).
             self._transcribe_checkpointed(audio_file, output_format, temp_output, language, verbose)
+            duration = self._checkpoint.transcription.elapsed_seconds
         else:
+            start_time = time.time()
             try:
                 run_whisper_transcription(
                     audio_file,
@@ -120,8 +125,7 @@ class WhisperTranscriptionProvider:
                 )
             except Exception as e:
                 raise TranscriptionError(f"Whisper transcription failed: {e}") from e
-
-        duration = time.time() - start_time
+            duration = time.time() - start_time
 
         # Save whisper JSON before diarization (so it survives diarization failures)
         whisper_json_path = None
@@ -216,6 +220,12 @@ class WhisperTranscriptionProvider:
             manifest.transcription.last_offset_ms = seg["to_ms"]
             manifest.transcription.segment_count += 1
 
+        # Time this leg and fold it into the manifest's cumulative total in a
+        # finally so a pause (TranscriptionPaused) or crash still records the
+        # active compute it consumed. Without this, a multi-session run would
+        # report only the final leg's duration - skewing the estimate-vs-actual
+        # line and poisoning the ETA training data with a falsely-fast ratio.
+        leg_start = time.time()
         try:
             run_whisper_transcription(
                 audio_file,
@@ -232,9 +242,11 @@ class WhisperTranscriptionProvider:
                 **self._opts,
             )
         except Exception:
-            # TranscriptionPaused and real failures both propagate; the JSONL holds
-            # everything decoded so far either way.
+            # TranscriptionPaused and real failures both propagate; the JSONL
+            # holds everything decoded so far either way.
             raise
+        finally:
+            manifest.add_transcription_elapsed(time.time() - leg_start)
 
         # Materialize the full, de-overlapped whisper JSON from the JSONL (single
         # source of truth across the resume seam).

--- a/tests/test_checkpoint_resume.py
+++ b/tests/test_checkpoint_resume.py
@@ -165,6 +165,53 @@ def test_segments_append_and_resume_offset(checkpoint_dir):
     assert len(m.load_segments()) == 2
 
 
+def test_elapsed_seconds_defaults_to_zero(checkpoint_dir):
+    m = _make_manifest()
+    assert m.transcription.elapsed_seconds == 0.0
+
+
+def test_add_transcription_elapsed_accumulates_across_legs(checkpoint_dir):
+    m = _make_manifest()
+    # Three resume legs: 12s + 8s + 5s = 25s of true cumulative compute.
+    assert m.add_transcription_elapsed(12.0) == pytest.approx(12.0)
+    assert m.add_transcription_elapsed(8.0) == pytest.approx(20.0)
+    total = m.add_transcription_elapsed(5.0)
+    assert total == pytest.approx(25.0)
+    assert m.transcription.elapsed_seconds == pytest.approx(25.0)
+
+
+def test_add_transcription_elapsed_persists(checkpoint_dir):
+    m = _make_manifest()
+    m.add_transcription_elapsed(7.5)
+    # Reload from disk: the accumulator survived the save().
+    loaded = cp.JobManifest.load(m.job_dir)
+    assert loaded is not None
+    assert loaded.transcription.elapsed_seconds == pytest.approx(7.5)
+
+
+def test_add_transcription_elapsed_clamps_negative(checkpoint_dir):
+    # A clock skew shouldn't subtract from the accumulated total.
+    m = _make_manifest()
+    m.add_transcription_elapsed(10.0)
+    assert m.add_transcription_elapsed(-3.0) == pytest.approx(10.0)
+
+
+def test_elapsed_seconds_survives_legacy_manifest_without_field(checkpoint_dir):
+    # A pre-upgrade manifest JSON has no elapsed_seconds; it must load with the
+    # 0.0 default rather than erroring.
+    import json
+
+    m = _make_manifest()
+    m.save()
+    raw = json.loads((m.job_dir / cp.MANIFEST_NAME).read_text())
+    raw["transcription"].pop("elapsed_seconds", None)
+    (m.job_dir / cp.MANIFEST_NAME).write_text(json.dumps(raw))
+
+    loaded = cp.JobManifest.load(m.job_dir)
+    assert loaded is not None
+    assert loaded.transcription.elapsed_seconds == 0.0
+
+
 def test_load_segments_tolerates_partial_trailing_line(checkpoint_dir):
     m = _make_manifest()
     m.append_segment({"from_ms": 0, "to_ms": 5000, "text": "a"})
@@ -374,3 +421,36 @@ def test_streaming_pause_raises_with_offset(fake_whisper):
     # Paused partway: at least the 3 we saw, fewer than all 10, offset matches last.
     assert 3 <= len(collected) < 10
     assert exc.value.last_offset_ms == collected[-1]["to_ms"]
+
+
+def test_checkpointed_transcribe_reports_cumulative_duration(
+    fake_whisper, checkpoint_dir, tmp_path
+):
+    """transcribe() on the checkpointed path returns total elapsed across legs.
+
+    A resumed run must report leg1 + leg2 + ..., not just the final leg, so the
+    estimate-vs-actual line and the persisted ETA stat reflect the true
+    end-to-end transcription time rather than a falsely-fast partial.
+    """
+    from pidcast.providers.whisper_provider import WhisperTranscriptionProvider
+
+    manifest = _make_manifest(job_id="cumuljob00001")
+    # Simulate a prior resume leg that already burned 42s of compute.
+    manifest.add_transcription_elapsed(42.0)
+
+    provider = WhisperTranscriptionProvider(
+        whisper_model="m",
+        output_format="json",
+        output_dir=tmp_path,
+        checkpoint=manifest,
+    )
+    result = provider.transcribe("dummy.wav", verbose=False)
+
+    # Reported duration includes the prior 42s plus this (small) leg's compute,
+    # i.e. the cumulative total - not just the final leg.
+    assert result.duration >= 42.0
+    # And the manifest's accumulator advanced past the seeded 42s.
+    reloaded = cp.JobManifest.load(manifest.job_dir)
+    assert reloaded is not None
+    assert reloaded.transcription.elapsed_seconds >= 42.0
+    assert reloaded.transcription.elapsed_seconds == pytest.approx(result.duration, abs=0.01)


### PR DESCRIPTION
## The bug

On `pidcast resume`, the whisper provider measured transcription duration as `time.time() - start_time` within the **current** process. So a resumed run reported only the **final leg's** compute — not the cumulative time across all sessions. Since the ETA is computed for the **full audio**, the `Estimation accuracy: X% faster than estimated` line was always nonsense on resume (full-audio estimate vs partial-leg actual).

**The worse consequence:** the bad number was *persisted*. The run record stored `audio_duration` = full but `transcription_duration` = leg-only, yielding a falsely-fast ratio in `runs.json`. With the new recency-weighted ETA (#29), which weights recent runs heavily, **every resumed run was actively poisoning future estimates**.

## Fix

Accumulate active transcription compute across legs in the checkpoint manifest:

- Add `PhaseState.elapsed_seconds` (defaults to `0.0`, so pre-upgrade manifests load unchanged) and `JobManifest.add_transcription_elapsed()`, which sums each leg's wall-clock and persists.
- Record the leg time in `_transcribe_checkpointed` inside a `finally`, so a **pause** (`TranscriptionPaused`) or a crash still books the compute it consumed — a multi-session run captures every leg, not just the one that finished cleanly.
- The checkpointed `transcribe()` path reports the **cumulative** total; the non-checkpoint path is byte-identical to today (single leg).

Only active transcription wall-clock is summed, so idle/paused time between sessions is never miscounted as compute.

## User-facing impact

After a paused-then-resumed transcription:
- The reported duration and the `Estimation accuracy` line reflect the **true end-to-end transcription time**, not a partial leg.
- The run no longer feeds a bogus fast ratio into the ETA model, so resumed runs stop degrading the accuracy of future estimates.

## Testing

- `tests/test_checkpoint_resume.py`: 6 new tests — accumulation across legs, persistence across save/load, negative-delta clamp, legacy-manifest-without-the-field load, and a provider-level test proving `transcribe()` returns the cumulative total through the real checkpointed path against the fake whisper binary.
- Full suite: 413 passed, 2 skipped. `ruff check src/` clean.

## Notes

The manifest schema gains a backward-compatible defaulted field (`SCHEMA_VERSION` unchanged — old manifests load with `elapsed_seconds=0.0`). A job that straddles the upgrade undercounts only its pre-upgrade leg, which is acceptable.

Version: 0.14.0 → 0.14.1 (PATCH — bug fix).
