### PR TITLE
Verb-first CLI grammar + single-owner run UI overhaul

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,17 +16,20 @@ Run with `uv run pidcast <input>`. Useful entry points:
 
 | Command | Purpose |
 |---------|---------|
-| `pidcast <URL_OR_PATH>` | Transcribe + analyze |
+| `pidcast <URL_OR_PATH>` | Transcribe + analyze (bare = `transcribe`) |
+| `pidcast transcribe <URL_OR_PATH>` | Transcribe + analyze (explicit verb) |
 | `pidcast setup` | Interactive setup wizard (env, deps, API keys) |
 | `pidcast doctor` | Diagnose tooling/env configuration |
-| `pidcast --analyze-existing transcript.md` | Re-analyze without re-transcribing |
-| `pidcast --diarize-existing transcript.md [--audio file]` | Retry diarization only |
-| `pidcast --test-segment [MIN] [--start-at MIN]` | Dry-run transcription on a slice |
-| `pidcast --transcription-provider {whisper,elevenlabs}` | Pick transcription backend |
-| `pidcast --vad [--vad-threshold N]` | Whisper anti-hallucination: strip silence via VAD (needs `WHISPER_VAD_MODEL`) |
-| `pidcast --provider {groq,claude}` | Pick LLM analysis backend |
+| `pidcast info` | Print resolved data/config dirs |
+| `pidcast analyze transcript.md` | Re-analyze without re-transcribing |
+| `pidcast diarize transcript.md [--audio file]` | Retry diarization only |
+| `pidcast transcribe <input> --test [MIN] [--start-at MIN]` | Dry-run transcription on a slice |
+| `pidcast transcribe <input> --transcription-provider {whisper,elevenlabs}` | Pick transcription backend |
+| `pidcast transcribe <input> --provider {groq,claude}` | Pick LLM analysis backend |
 | `pidcast lib {add,list,show,remove,sync,process,digest}` | Manage podcast subscriptions |
-| `pidcast -L \| -M \| -W \| -P` | List analysis types / LLM models / Whisper models / presets |
+| `pidcast list {analyses,models,whisper-models,presets,profiles}` | List analysis types / LLM models / Whisper models / presets / Chrome profiles |
+
+The CLI is verb-first (one `argparse` subparser per verb, wired in `cli.py` via `set_defaults(func=...)`); bare `pidcast <input>` injects the `transcribe` verb. Advanced whisper-tuning flags (`--vad`, `--vad-threshold`, `--temperature`, `--no-speech-thold`, `--no-fallback`, `--whisper-threads`) are hidden from `--help` (still settable; supply via config.yaml presets).
 
 Environment: copy `.env.example` → `.env`. See [docs/development-guide.md](docs/development-guide.md) for the full var list.
 
@@ -44,7 +47,9 @@ pre-commit install           # enable pre-commit hooks (ruff, mermaid)
 
 Source lives under `src/pidcast/`. Hot-path modules (read these first when debugging a workflow):
 
-- `cli.py` — argparse surface; dispatches to `workflow.py` and the `lib` subcommands
+- `cli.py` — thin argparse surface: builds the verb subparser tree + shared parent parsers, then `args.func(args)`
+- `commands/` — one module per verb (`transcribe`, `analyze`, `diarize`, `listing`, `info`, `lib`); handler bodies live here, not in `cli.py`
+- `duplicate.py` — duplicate-detection prompt UI (consumed by `commands/transcribe.py`)
 - `workflow.py` — orchestration: download → transcribe → diarize → analyze → write
 - `transcription.py` + `providers/` — provider dispatch for whisper/ElevenLabs
 - `diarization.py` — pyannote integration; consumes whisper JSON or ElevenLabs speakers
@@ -66,12 +71,12 @@ Source lives under `src/pidcast/`. Hot-path modules (read these first when debug
 - **Chunking threshold:** transcripts > 120k chars use semantic chunking with synthesis.
 - **LLM responses:** every analysis prompt returns JSON with `analysis` and `contextual_tags` fields.
 - **Filenames:** smart-filtered with `YYYY-MM-DD_Title.md` date prefix.
-- **Transcripts location:** the canonical store is the XDG data dir, `$XDG_DATA_HOME/pidcast/transcripts/` (default `~/.local/share/pidcast/transcripts/`; override with `PIDCAST_DATA_DIR`; run `pidcast paths` to print the resolved dirs). Audio, logs, and the unified run history (`state/runs.json`) live alongside it under the data dir. Never drop stray transcripts in the repo root (ignored via `.gitignore`).
+- **Transcripts location:** the canonical store is the XDG data dir, `$XDG_DATA_HOME/pidcast/transcripts/` (default `~/.local/share/pidcast/transcripts/`; override with `PIDCAST_DATA_DIR`; run `pidcast info` to print the resolved dirs). Audio, logs, and the unified run history (`state/runs.json`) live alongside it under the data dir. Never drop stray transcripts in the repo root (ignored via `.gitignore`).
 - **Linting:** ruff is the single source of truth (config in `pyproject.toml` under `[tool.ruff]`).
 
 ## Data handling
 
-The transcripts dir (`$XDG_DATA_HOME/pidcast/transcripts/`, run `pidcast paths`) contains large text files (some > 200 KB). The repo's `data/transcripts/` may still hold pre-migration files. **Do NOT read these into context** unless the user explicitly approves a specific file. For test fixtures, ask the user to point at one or create a dedicated minimal fixture under `tests/`.
+The transcripts dir (`$XDG_DATA_HOME/pidcast/transcripts/`, run `pidcast info`) contains large text files (some > 200 KB). The repo's `data/transcripts/` may still hold pre-migration files. **Do NOT read these into context** unless the user explicitly approves a specific file. For test fixtures, ask the user to point at one or create a dedicated minimal fixture under `tests/`.
 
 ## Further reading
 

--- a/README.md
+++ b/README.md
@@ -83,21 +83,23 @@ uv run pidcast "URL" --vad
 uv run pidcast "URL" --vad --vad-threshold 0.6   # raise the speech-probability cutoff
 
 # Test settings on a 2-minute slice before committing to a long run
-uv run pidcast "URL" --test-segment
+uv run pidcast "URL" --test
 
 # Reuse an existing transcript
-uv run pidcast --analyze-existing transcript.md          # re-analyze
-uv run pidcast --diarize-existing transcript.md          # retry diarization
+uv run pidcast analyze transcript.md          # re-analyze
+uv run pidcast diarize transcript.md          # retry diarization
 
-# Discovery flags
-uv run pidcast -L     # list analysis types
-uv run pidcast -M     # list LLM models
-uv run pidcast -W     # list Whisper models
-uv run pidcast -P     # list presets
-uv run pidcast paths  # show where transcripts, audio, logs, and run history live
+# Discovery
+uv run pidcast list analyses         # list analysis types
+uv run pidcast list models           # list LLM models
+uv run pidcast list whisper-models   # list Whisper models
+uv run pidcast list presets          # list presets
+uv run pidcast info                  # show where transcripts, audio, logs, and run history live
 ```
 
-By default, transcripts, kept audio, logs, and the run history live under the XDG data dir (`~/.local/share/pidcast/`, or `$XDG_DATA_HOME/pidcast/`) — not in the repo. Override the whole tree with `PIDCAST_DATA_DIR`, set a fixed transcript directory with `--output-dir` or the `output_dir` key in `~/.config/pidcast/config.yaml`, and run `pidcast paths` to see what resolves.
+`pidcast` is verb-first: bare `pidcast "URL"` is shorthand for `pidcast transcribe "URL"`. Run `pidcast --help` for the full command list, or `pidcast <command> --help` for a command's flags.
+
+By default, transcripts, kept audio, logs, and the run history live under the XDG data dir (`~/.local/share/pidcast/`, or `$XDG_DATA_HOME/pidcast/`) — not in the repo. Override the whole tree with `PIDCAST_DATA_DIR`, set a fixed transcript directory with `--output-dir` or the `output_dir` key in `~/.config/pidcast/config.yaml`, and run `pidcast info` to see what resolves.
 
 Available analysis types: `executive_summary` (default), `summary`, `key_points`, `action_items`, `comprehensive`. Every type ends with a **Shareable Brief** — a punchy headline (≤ 15 words) plus a 3–5 sentence quick-take suitable for sending to a friend.
 
@@ -153,7 +155,7 @@ uv run pidcast-eval --compare groq,claude --transcript-file transcript.txt --tit
 uv run pidcast-eval --run-matrix           # all prompt × model × reference combos
 ```
 
-Reports land under the data dir, in `evals/comparisons/` (run `pidcast paths` to resolve it; default `~/.local/share/pidcast/evals/comparisons/`). See [docs/development-guide.md](docs/development-guide.md#provider-comparison-evals) for the full eval matrix flags.
+Reports land under the data dir, in `evals/comparisons/` (run `pidcast info` to resolve it; default `~/.local/share/pidcast/evals/comparisons/`). See [docs/development-guide.md](docs/development-guide.md#provider-comparison-evals) for the full eval matrix flags.
 
 ## 📚 Documentation <a name="documentation"></a>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,7 +153,7 @@ Transcripts whose text length exceeds **120 000 characters** are routed through 
 | Audio normalize | `ffmpeg: command not found` | `pidcast doctor` flags it |
 | Transcription (whisper) | Missing model file | `pidcast doctor` flags it; `setup.py` can download |
 | Transcription (elevenlabs) | 401, 413 (payload too large) | `transcription.py` retries with smaller chunks for 413 |
-| Diarization | HUGGINGFACE_TOKEN missing or model license not accepted | Raises `DiarizationError`; see `--diarize-existing` to retry separately |
+| Diarization | HUGGINGFACE_TOKEN missing or model license not accepted | Raises `DiarizationError`; see `pidcast diarize <transcript>` to retry separately |
 | Analysis | Rate limit, JSON parse failure | `model_selector.py` falls back through `config/models.yaml` chain |
 
 ## Related docs

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -90,7 +90,7 @@ scripts/              # migrate_data.py and other one-shot helpers
 ```
 
 There is no repo-local `data/` dir: all generated artifacts (transcripts, audio,
-logs, run history, and eval output) live in the XDG data dir. Run `pidcast paths`.
+logs, run history, and eval output) live in the XDG data dir. Run `pidcast info`.
 
 ## Project conventions
 
@@ -98,7 +98,7 @@ logs, run history, and eval output) live in the XDG data dir. Run `pidcast paths
 - **LLM responses:** all analysis prompts return JSON with `analysis` and `contextual_tags` fields. Add fields via `config/prompts.yaml`, not via prompt-string surgery in code.
 - **Chunking threshold:** 120 000 characters triggers semantic chunking with synthesis. Threshold lives in `config.py`.
 - **Filenames:** smart-prefixed `YYYY-MM-DD_Title.md`. Logic in `utils.py`.
-- **Transcripts canonical location:** the XDG data dir, `$XDG_DATA_HOME/pidcast/transcripts/` (default `~/.local/share/pidcast/transcripts/`; override the tree with `PIDCAST_DATA_DIR`; run `pidcast paths`). Audio (`audio/`), logs (`logs/`), and the unified run history (`state/runs.json`) live alongside it; config and the podcast library stay in `~/.config/pidcast/`. The repo gitignores stray `YYYY-MM-DD_*.md` files at the root.
+- **Transcripts canonical location:** the XDG data dir, `$XDG_DATA_HOME/pidcast/transcripts/` (default `~/.local/share/pidcast/transcripts/`; override the tree with `PIDCAST_DATA_DIR`; run `pidcast info`). Audio (`audio/`), logs (`logs/`), and the unified run history (`state/runs.json`) live alongside it; config and the podcast library stay in `~/.config/pidcast/`. The repo gitignores stray `YYYY-MM-DD_*.md` files at the root.
 
 ## Provider comparison evals
 
@@ -110,7 +110,7 @@ uv run pidcast-eval --run-matrix                              # all prompt × mo
 uv run pidcast-eval --run-matrix --models "llama-3.3-70b-versatile,mixtral-8x7b-32768"
 ```
 
-Eval fixtures (prompts registry + reference transcripts) ship inside the package at `src/pidcast/evals/data/` and resolve via `importlib.resources`, so `pidcast-eval` works from an installed wheel as well as a source checkout. Generated output (runs, batches, comparisons, `cost_tracking.json`) is written under the XDG data dir at `<data-dir>/evals/` (run `pidcast paths`). See `src/pidcast/evals/` for the underlying machinery and `src/pidcast/evals/paths.py` for path resolution.
+Eval fixtures (prompts registry + reference transcripts) ship inside the package at `src/pidcast/evals/data/` and resolve via `importlib.resources`, so `pidcast-eval` works from an installed wheel as well as a source checkout. Generated output (runs, batches, comparisons, `cost_tracking.json`) is written under the XDG data dir at `<data-dir>/evals/` (run `pidcast info`). See `src/pidcast/evals/` for the underlying machinery and `src/pidcast/evals/paths.py` for path resolution.
 
 ## CI
 

--- a/docs/superpowers/specs/2026-06-30-duplicate-prompt-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-30-duplicate-prompt-redesign-design.md
@@ -1,0 +1,82 @@
+# Duplicate-detection prompt redesign
+
+## Context
+
+After the Phase 1-3 CLI/UX refactor, the transcription run output is polished (single owned rich Live display, clean phase lines). But the interactive **duplicate-detection prompt** — shown when a recording was already transcribed — was carried over untouched and now looks dated next to the rest of the run. The dated feel comes from three things:
+
+1. A heavy stacked layout: a bordered panel, then a loose key/value `rich.Table`, then a loose numbered list.
+2. "Type a number then Enter" interaction (`Enter choice [1/2/3/4] (4):`), the giveaway of an old CLI.
+3. Inconsistent density vs. the compact `✓ phase`-line style the run now uses.
+
+The current implementation lives in `src/pidcast/duplicate.py` (`prompt_duplicate_detected` + `_prompt_duplicate_basic`). It returns a `DuplicateAction` enum consumed by `commands/transcribe.py`; that contract is unchanged by this work.
+
+**Intended outcome:** a compact, modern prompt — one rounded panel containing the info and the choices — with instant single-keypress selection, no new dependency, and a clean non-TTY fallback.
+
+## Decisions (locked)
+
+- **Layout:** one rounded `rich` panel containing a title line, a one-line metadata summary, and a bracketed-key choices line.
+- **Interaction:** single keypress (`r`/`a`/`f`/`c`), acts instantly, no Enter. Case-insensitive. Enter alone selects the default; Esc / Ctrl-C / EOF select cancel.
+- **No new dependency:** `rich` (already present) + a tiny `termios`/`tty` raw-keypress helper from the stdlib.
+- **Fallback:** when stdin is not a TTY, or `termios` is unavailable (e.g. Windows), or rich is missing, fall back to a line-based `input()` prompt. (Non-interactive duplicate handling already errors out upstream in `commands/transcribe.py` via `is_interactive()`, so the prompt is only reached interactively; the fallback is the safety net for odd terminals.)
+- **Scope:** only the duplicate prompt changes now. The `lib process` episode picker and `discovery.prompt_user_selection` keep their current behavior. The new `select_key` helper is placed where they could adopt it later, but converting them is out of scope (YAGNI).
+
+## Components
+
+### `ui.select_key(prompt, choices, *, default)` — new, in `src/pidcast/ui.py`
+
+A reusable single-keypress selector. `ui.py` is the established home for terminal-UI concerns (it already owns the run's Console/Live).
+
+- **Signature:** `select_key(prompt: str, choices: list[tuple[str, str]], *, default: str) -> str`
+  - `choices`: ordered `(key, label)` pairs, e.g. `[("r", "re-transcribe"), ("a", "analyze"), ("f", "force"), ("c", "cancel")]`. `key` is a single lowercase character.
+  - `default`: the key returned on Enter / empty input. Must be one of the choice keys.
+  - Returns the selected key (lowercase).
+- **TTY path:** read one raw byte via `termios`/`tty` (set cbreak, restore in `finally`). Match case-insensitively against the choice keys. Enter/`\r`/`\n` → `default`. Esc (`\x1b`), Ctrl-C (`\x03`), EOF → return the `"c"`/cancel key if present, else `default`. An unrecognized key re-reads (no echo spam) until a valid key or an exit key arrives.
+- **Non-TTY / no-termios path:** print the bracketed-key hint line once, then loop on `input()` reading a line; first character is matched the same way; empty line → default; EOF → cancel/default.
+- **Isolation:** pure function of stdin/stdout. The raw-getch is a small inner helper so tests can monkeypatch it. No dependency on `RunReporter` state.
+
+### `prompt_duplicate_detected(prev, verbose=False)` — rewritten, in `src/pidcast/duplicate.py`
+
+- Build the metadata summary line from `prev`: `formatted_date` + (analysis type if `prev.analysis_performed`) + transcript status (`on disk` vs `file not found`), separated by ` · `.
+- Render ONE `rich` panel (rounded box, `title="Already transcribed"`, yellow border) whose body is:
+  - line 1: `prev.video_title` (bold)
+  - line 2: the dimmed metadata summary
+  - blank line
+  - the choices line: `[r] re-transcribe   [a] analyze   [f] force   [c] cancel` with the bracketed key letters highlighted (cyan), the `a` option included only when the transcript file exists.
+- Call `select_key("", choices, default="c")` where `choices` omits `a` when `prev.transcript_path` is missing.
+- Map the returned key to `DuplicateAction`:
+  - `r` → `RE_TRANSCRIBE`, `a` → `ANALYZE_EXISTING`, `f` → `FORCE_CONTINUE`, `c` → `CANCEL`.
+- Remove `_prompt_duplicate_basic`. When rich is missing, render the info as plain `print()` lines (title + metadata) and call `select_key`, which itself handles the no-rich/non-TTY case via its `input()` fallback. This deletes the separate numbered-prompt code path entirely (one selection mechanism, not two).
+
+The function signature, return type, and the four `DuplicateAction` values are unchanged, so `commands/transcribe.py`'s dispatch needs no edits.
+
+## Data flow
+
+`commands/transcribe.cmd_transcribe` (unchanged) → on duplicate + interactive → `prompt_duplicate_detected(prev, verbose)` → builds panel, calls `ui.select_key(...)` → `select_key` reads one key (TTY) or a line (fallback) → returns key → mapped to `DuplicateAction` → returned to the existing dispatch.
+
+## Error handling
+
+- `termios`/`tty` import or `tcgetattr` failure → fall straight to the `input()` fallback (wrapped in try/except).
+- Terminal state is always restored in a `finally` (cbreak → original), so a raised `KeyboardInterrupt` mid-read doesn't leave the terminal in raw mode.
+- Ctrl-C / Esc / EOF resolve to cancel — never crash the prompt.
+
+## Testing
+
+New `tests/test_duplicate_prompt.py` (the existing `test_duplicate_detection.py` covers detection logic and stays untouched):
+
+- `select_key`:
+  - TTY keypress matches the right key (monkeypatch the inner getch to feed `"r"`, assert `"r"`).
+  - case-insensitive (`"R"` → `"r"`).
+  - Enter / empty → default.
+  - Esc / Ctrl-C / EOF → cancel key.
+  - invalid key then valid key → returns the valid one (re-read loop).
+  - non-TTY: monkeypatch `isatty` False, feed `input()` → returns first-char match.
+- `prompt_duplicate_detected`:
+  - each key maps to the correct `DuplicateAction` (monkeypatch `select_key`).
+  - `a` choice omitted (and `a` keypress not offered) when `prev.transcript_path` does not exist.
+
+Verification: `uv run pytest`, `uv run ruff check src/ tests/`, and a manual run under a real terminal (trigger a duplicate, confirm the panel renders and a single keypress acts instantly) plus a piped run (confirm the `input()` fallback engages without raw-mode artifacts).
+
+## Out of scope
+
+- The `lib process` episode picker (`commands/lib.py`) and `discovery.prompt_user_selection` — they may adopt `select_key` later but are not changed here.
+- Arrow-key navigation / any new prompt dependency (explicitly rejected: rich-only).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidcast"
-version = "0.14.1"
+version = "0.15.0"
 description = "YouTube transcription tool with Whisper and LLM analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidcast"
-version = "0.16.0"
+version = "0.17.0"
 description = "YouTube transcription tool with Whisper and LLM analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidcast"
-version = "0.15.0"
+version = "0.16.0"
 description = "YouTube transcription tool with Whisper and LLM analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pidcast/analysis.py
+++ b/src/pidcast/analysis.py
@@ -962,6 +962,41 @@ def _analyze_with_chunking_rich(
     This is a thin wrapper that sets up Rich progress and delegates to
     _analyze_with_chunking with a progress callback.
     """
+    from .ui import active_reporter
+
+    # Estimate chunk count for the progress total.
+    effective_limit = selector.get_effective_token_limit(preferred_model)
+    chunk_target_tokens = max(effective_limit - 3000, 2000)
+    estimated_chunks = max(1, estimate_tokens(transcript) // chunk_target_tokens)
+
+    reporter = active_reporter()
+    if reporter is not None and reporter.is_live:
+        # Drive the run's single shared display instead of a competing Progress.
+        shared = reporter.task("Analyzing chunks...", total=estimated_chunks)
+
+        def progress_callback(prog: ChunkProgress) -> None:
+            if prog.phase == "chunk":
+                shared.update(
+                    completed=prog.current,
+                    description=f"Analyzing chunk {prog.current}/{prog.total}",
+                )
+            elif prog.phase == "synthesis":
+                shared.update(description="Synthesizing results...")
+
+        try:
+            return _analyze_with_chunking(
+                transcript,
+                video_info,
+                prompts_config,
+                client,
+                selector,
+                preferred_model,
+                verbose,
+                progress_callback=progress_callback,
+            )
+        finally:
+            shared.finish()
+
     try:
         from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
     except ImportError:
@@ -970,7 +1005,7 @@ def _analyze_with_chunking_rich(
             transcript, video_info, prompts_config, client, selector, preferred_model, verbose
         )
 
-    # Create progress context and callback
+    # Create progress context and callback (standalone: own the Progress).
     progress_context = Progress(
         SpinnerColumn(),
         TextColumn("[cyan]{task.description}"),
@@ -992,10 +1027,6 @@ def _analyze_with_chunking_rich(
             progress_context.update(task_id, description="Synthesizing results...")
 
     with progress_context as progress:
-        # Estimate chunks for progress bar (rough estimate based on token limit)
-        effective_limit = selector.get_effective_token_limit(preferred_model)
-        chunk_target_tokens = max(effective_limit - 3000, 2000)
-        estimated_chunks = max(1, estimate_tokens(transcript) // chunk_target_tokens)
         task_id = progress.add_task("Analyzing chunks...", total=estimated_chunks)
 
         return _analyze_with_chunking(

--- a/src/pidcast/cli.py
+++ b/src/pidcast/cli.py
@@ -529,6 +529,40 @@ def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(_inject_default_verb(argv))
 
 
+def _suppress_all_defaults(parser: argparse.ArgumentParser) -> None:
+    """Set every action's default to SUPPRESS, recursing into subparsers.
+
+    After this, a parse only populates dests the user actually supplied — the
+    basis for robust explicit-flag detection across any flag spelling.
+    """
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            for sub in action.choices.values():
+                _suppress_all_defaults(sub)
+        else:
+            action.default = argparse.SUPPRESS
+
+
+def _explicitly_set_dests(argv: list[str]) -> set[str]:
+    """Return the dests the user explicitly passed, by any spelling.
+
+    Re-parses ``argv`` through a shadow parser whose defaults are all SUPPRESS,
+    so only supplied options appear in the result. This correctly catches short
+    aliases (``-m``) and ``BooleanOptionalAction`` (``--no-suppress-nst``) that a
+    naive ``sys.argv`` substring scan misses.
+    """
+    shadow = _build_parser()
+    _suppress_all_defaults(shadow)
+    try:
+        ns, _ = shadow.parse_known_args(_inject_default_verb(argv))
+    except SystemExit:
+        # A parse error here shouldn't crash preset handling; fall back to "none
+        # detected" so explicit flags simply aren't protected (preset still safe).
+        return set()
+    # `command`/`func` are structural, not user flags; drop them.
+    return {k for k in vars(ns) if k not in ("command", "func")}
+
+
 def _inject_default_verb(argv: list[str]) -> list[str]:
     """Inject the implicit ``transcribe`` verb for the bare-input shortcut.
 
@@ -577,16 +611,12 @@ def main() -> None:
 
     setup_logging(getattr(args, "verbose", False))
 
-    # Apply preset if specified (transcribe/lib paths carry -p).
+    # Apply preset if specified (transcribe/lib paths carry -p). Detect which
+    # flags the user passed (by any spelling) so the preset never clobbers them.
     if getattr(args, "preset", None):
         import sys
 
-        explicitly_set = set()
-        for arg in vars(args):
-            if any(
-                a in (f"--{arg}", f"-{arg}", f"--{arg.replace('_', '-')}") for a in sys.argv[1:]
-            ):
-                explicitly_set.add(arg)
+        explicitly_set = _explicitly_set_dests(sys.argv[1:])
         try:
             apply_preset(args, explicitly_set=explicitly_set)
         except ValueError as e:

--- a/src/pidcast/cli.py
+++ b/src/pidcast/cli.py
@@ -1,181 +1,44 @@
-"Command-line interface for pidcast."
+"""Command-line interface for pidcast.
+
+Thin parser + dispatch layer. Every verb is a real subparser with a ``func``
+default; command bodies live in ``commands/`` and the domain modules
+(``library``/``setup``/``resume``). ``main()`` loads env, injects the bare-input
+shortcut, parses, configures logging, and calls ``args.func(args)``.
+"""
 
 import argparse
-import datetime
 import logging
-import os
-import time
-import traceback
-import uuid
-from enum import Enum
-from pathlib import Path
 
 from .config import (
     DEFAULT_PROMPTS_FILE,
     OBSIDIAN_PATH,
     RUNS_FILE,
-    TRANSCRIPTS_DIR,
     WHISPER_MODEL,
+    resolve_output_dir,  # re-exported for backwards-compatible imports/tests
 )
-from .exceptions import DuplicateShowError, FeedFetchError, FeedParseError, ShowNotFoundError
-from .utils import (
-    find_existing_transcription,
-    is_interactive,
-    log_error,
-    log_section,
-    setup_logging,
-)
-from .workflow import (
-    process_input_source,
-    run_analyze_existing_mode,
-)
+from .utils import log_error, setup_logging
 
 logger = logging.getLogger(__name__)
 
-
-# ============================================================================
-# DUPLICATE DETECTION
-# ============================================================================
-
-
-class DuplicateAction(Enum):
-    """User's choice when duplicate transcription is detected."""
-
-    RE_TRANSCRIBE = "retranscribe"
-    ANALYZE_EXISTING = "analyze"
-    FORCE_CONTINUE = "force"
-    CANCEL = "cancel"
+# Re-export so callers/tests that did `from .cli import resolve_output_dir`
+# keep working after the move to config.py.
+__all__ = ["main", "parse_arguments", "build_transcribe_namespace", "resolve_output_dir"]
 
 
-def prompt_duplicate_detected(
-    prev,
-    verbose: bool = False,
-) -> DuplicateAction:
-    """Display duplicate detection UI and get user's choice.
-
-    Args:
-        prev: Information about the previous transcription (PreviousTranscription)
-        verbose: Enable verbose output
-
-    Returns:
-        User's selected action
-    """
-
-    try:
-        from rich.console import Console
-        from rich.panel import Panel
-        from rich.prompt import Prompt
-        from rich.table import Table
-    except ImportError:
-        return _prompt_duplicate_basic(prev)
-
-    console = Console()
-
-    # Build info panel
-    console.print()
-    console.print(
-        Panel(
-            "[yellow bold]Duplicate Detected![/yellow bold]\n\n"
-            "This recording was previously transcribed.",
-            border_style="yellow",
-        )
-    )
-
-    # Show previous transcription details
-    table = Table(show_header=False, box=None, padding=(0, 2))
-    table.add_column(style="cyan", width=20)
-    table.add_column(style="white")
-
-    table.add_row("Title", prev.video_title)
-    table.add_row("Transcribed", prev.formatted_date)
-    table.add_row("File", prev.smart_filename)
-
-    # Check if transcript file still exists
-    transcript_exists = prev.transcript_path.exists()
-    if transcript_exists:
-        table.add_row("Status", "[green]Transcript file exists[/green]")
-    else:
-        table.add_row("Status", "[red]Transcript file not found[/red]")
-
-    if prev.analysis_performed:
-        table.add_row("Previous Analysis", prev.analysis_type or "Yes")
-
-    console.print(table)
-    console.print()
-
-    # Build options
-    console.print("[bold]What would you like to do?[/bold]")
-    console.print()
-    console.print("  [cyan]1[/cyan] - Re-transcribe the recording")
-
-    if transcript_exists:
-        console.print("  [cyan]2[/cyan] - Analyze existing transcript (skip re-transcription)")
-    else:
-        console.print("  [dim]2 - Analyze existing (unavailable - file not found)[/dim]")
-
-    console.print("  [cyan]3[/cyan] - Continue anyway (force re-transcription)")
-    console.print("  [cyan]4[/cyan] - Cancel")
-    console.print()
-
-    # Get choice
-    valid_choices = ["1", "2", "3", "4"] if transcript_exists else ["1", "3", "4"]
-    while True:
-        choice = Prompt.ask(
-            "Enter choice",
-            choices=valid_choices,
-            default="4",
-        )
-
-        if choice == "1":
-            return DuplicateAction.RE_TRANSCRIBE
-        elif choice == "2" and transcript_exists:
-            return DuplicateAction.ANALYZE_EXISTING
-        elif choice == "3":
-            return DuplicateAction.FORCE_CONTINUE
-        elif choice == "4":
-            return DuplicateAction.CANCEL
-
-
-def _prompt_duplicate_basic(prev) -> DuplicateAction:
-    """Basic fallback prompt without rich.
-
-    Args:
-        prev: Information about the previous transcription (PreviousTranscription)
-    """
-    print("\n" + "=" * 60)
-    print("DUPLICATE DETECTED!")
-    print("=" * 60)
-    print(f"Title: {prev.video_title}")
-    print(f"Previously transcribed: {prev.formatted_date}")
-    print(f"File: {prev.smart_filename}")
-    print()
-    print("Options:")
-    print("  1 - Re-transcribe the recording")
-    print("  2 - Analyze existing transcript")
-    print("  3 - Continue anyway")
-    print("  4 - Cancel")
-    print()
-
-    transcript_exists = prev.transcript_path.exists()
-    valid_choices = {"1", "3", "4"}
-    if transcript_exists:
-        valid_choices.add("2")
-    else:
-        print("  (Option 2 unavailable - transcript file not found)")
-
-    while True:
-        choice = input("Enter choice [4]: ").strip() or "4"
-        if choice in valid_choices:
-            break
-        print(f"Invalid choice. Please enter: {', '.join(sorted(valid_choices))}")
-
-    mapping = {
-        "1": DuplicateAction.RE_TRANSCRIBE,
-        "2": DuplicateAction.ANALYZE_EXISTING,
-        "3": DuplicateAction.FORCE_CONTINUE,
-        "4": DuplicateAction.CANCEL,
+# Verbs that the bare-input shortcut must NOT treat as a transcription input.
+KNOWN_VERBS = frozenset(
+    {
+        "transcribe",
+        "analyze",
+        "diarize",
+        "lib",
+        "list",
+        "setup",
+        "doctor",
+        "resume",
+        "info",
     }
-    return mapping[choice]
+)
 
 
 # ============================================================================
@@ -221,1460 +84,503 @@ def apply_preset(
 # ============================================================================
 
 
-def parse_arguments() -> argparse.Namespace:
-    """Parse command-line arguments.
+def _build_parent_parsers() -> dict[str, argparse.ArgumentParser]:
+    """Shared flag groups, passed to verbs via ``parents=[...]``.
 
-    Returns:
-        Parsed arguments namespace
+    Keeps the common analysis/whisper/output/global flags defined once instead
+    of duplicated across transcribe / lib process / lib sync.
     """
-    import sys
+    parents: dict[str, argparse.ArgumentParser] = {}
 
-    # Check if first argument is 'lib' to determine which parser to use
-    is_lib_command = len(sys.argv) > 1 and sys.argv[1] == "lib"
-
-    parser = argparse.ArgumentParser(
-        description="Automate audio transcription with Whisper (YouTube URL or local file).",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Common Workflows:
-  # Quick transcription with defaults
-  %(prog)s "https://www.youtube.com/watch?v=VIDEO_ID"
-
-  # Save to Obsidian vault
-  %(prog)s "VIDEO_URL" -o
-
-  # Custom analysis type (supports fuzzy matching)
-  %(prog)s "VIDEO_URL" -o -a exec          # Matches 'executive_summary'
-  %(prog)s "VIDEO_URL" -o -a detailed -v   # Verbose output
-
-  # Choose specific model
-  %(prog)s "VIDEO_URL" -m llama33           # Matches 'llama-3.3-70b-versatile'
-
-  # Test settings on a short segment before full transcription
-  %(prog)s "VIDEO_URL" --test-segment --diarize
-  %(prog)s "VIDEO_URL" --test-segment 5 --start-at 10
-
-  # Analyze existing transcript
-  %(prog)s --analyze-existing transcript.md -a summary
-
-  # Retry diarization on existing transcript (without re-transcribing)
-  %(prog)s --diarize-existing transcript.md
-
-Discovery:
-  %(prog)s -L                              # List analysis types
-  %(prog)s -M                              # List LLM models
-  %(prog)s -W                              # List Whisper models
-
-Library Management:
-  %(prog)s lib add "https://feeds.example.com/podcast.xml"
-  %(prog)s lib process "Lex Fridman" --latest
-  %(prog)s lib list
-  %(prog)s lib sync
-
-Short Flags:
-  -o  --save-to-obsidian    Save to Obsidian vault
-  -a  --analysis-type       Analysis type (fuzzy matching enabled)
-  -m  --groq-model          Model name (fuzzy matching enabled)
-  -l  --language            Language code for transcription
-  -f  --force               Force re-transcription
-  -v  --verbose             Verbose output
-  -p  --preset              Use a named preset
-  -L  --list-analyses       List available analysis types
-  -M  --list-models         List available LLM models
-  -W  --list-whisper-models List available Whisper models
-  -P  --list-presets        List available presets
-        """,
+    # --- global (verbosity / force / preset) ---------------------------------
+    g = argparse.ArgumentParser(add_help=False)
+    g.add_argument("-v", "--verbose", action="store_true", help="Enable verbose output")
+    g.add_argument(
+        "-f", "--force", action="store_true", help="Skip duplicate detection and force the run"
     )
-
-    # Only create subparsers if 'lib' command is used
-    if is_lib_command:
-        subparsers = parser.add_subparsers(dest="mode", help="Command mode", required=False)
-
-        # Library subcommand with nested subparsers
-        lib_parser = subparsers.add_parser("lib", help="Podcast library management")
-        lib_subparsers = lib_parser.add_subparsers(
-            dest="lib_command", help="Library management commands", required=True
-        )
-
-        # Add command
-        add_parser = lib_subparsers.add_parser("add", help="Add podcast to library")
-        add_parser.add_argument("feed_url", help="RSS feed URL or podcast name to search for")
-        add_parser.add_argument(
-            "--preview", action="store_true", help="Preview episodes before adding"
-        )
-        add_parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
-
-        # Process command (NEW)
-        process_parser = lib_subparsers.add_parser(
-            "process", help="Process an episode from a library show"
-        )
-        process_parser.add_argument("show_query", help="Show ID or partial name")
-        process_parser.add_argument(
-            "--latest", action="store_true", help="Process the latest episode"
-        )
-        process_parser.add_argument("--match", help="Process episode matching this title string")
-        # Reuse common flags for processing
-        process_parser.add_argument("--output-dir", dest="output_dir", help="Output directory")
-        process_parser.add_argument(
-            "--save-to-obsidian",
-            dest="save_to_obsidian",
-            action="store_true",
-            help="Save to Obsidian",
-        )
-        process_parser.add_argument(
-            "--whisper-model", dest="whisper_model", help="Whisper model path"
-        )
-        process_parser.add_argument("--groq-api-key", dest="groq_api_key", help="Groq API key")
-        process_parser.add_argument(
-            "--analysis-type",
-            dest="analysis_type",
-            default="executive_summary",
-            help="Analysis type",
-        )
-        process_parser.add_argument("--prompts-file", dest="prompts_file", help="Prompts file path")
-        process_parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
-        process_parser.add_argument("--force", action="store_true", help="Force reprocessing")
-        process_parser.add_argument(
-            "--output-format", dest="output_format", default="otxt", help="Output format"
-        )
-        process_parser.add_argument(
-            "--keep-transcript", dest="keep_transcript", action="store_true", help="Keep transcript"
-        )
-        process_parser.add_argument("--po-token", dest="po_token", help="PO Token")
-        process_parser.add_argument(
-            "--cookies-from-browser",
-            default=None,
-            help="Browser to extract cookies from (e.g., 'chrome', 'firefox', 'safari')",
-        )
-        process_parser.add_argument(
-            "--cookies",
-            default=None,
-            help="Path to Netscape format cookies file",
-        )
-        process_parser.add_argument(
-            "--chrome-profile",
-            default=None,
-            dest="chrome_profile",
-            help="Chrome profile for cookie extraction (display name or directory name)",
-        )
-        process_parser.add_argument(
-            "--front-matter", dest="front_matter", default="{}", help="Front matter JSON"
-        )
-        process_parser.add_argument("--save", action="store_true", help="Save output")
-        process_parser.add_argument(
-            "--no-analyze", dest="no_analyze", action="store_true", help="Skip analysis"
-        )
-        process_parser.add_argument(
-            "--skip-analysis-on-error",
-            dest="skip_analysis_on_error",
-            action="store_true",
-            help="Skip analysis on error",
-        )
-        process_parser.add_argument("--stats-file", dest="stats_file", help="Stats file path")
-        process_parser.add_argument("--groq-model", dest="groq_model", help="Groq model")
-        process_parser.add_argument(
-            "--provider",
-            default="groq",
-            choices=["groq", "claude"],
-            help="LLM provider: 'groq' (default) or 'claude'",
-        )
-        process_parser.add_argument(
-            "--claude-model",
-            dest="claude_model",
-            default=None,
-            help="Claude model alias when --provider claude: sonnet (default), opus, haiku",
-        )
-
-        # List command
-        list_parser = lib_subparsers.add_parser("list", help="List all shows in library")
-        list_parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
-
-        # Show command
-        show_parser = lib_subparsers.add_parser("show", help="Show details for a podcast")
-        show_parser.add_argument("show_id", type=int, help="Show ID")
-        show_parser.add_argument(
-            "--episodes", type=int, default=5, help="Number of recent episodes to show (default: 5)"
-        )
-        show_parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
-
-        # Remove command
-        remove_parser = lib_subparsers.add_parser("remove", help="Remove podcast from library")
-        remove_parser.add_argument("show_id", type=int, help="Show ID")
-        remove_parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
-
-        # Sync command
-        sync_parser = lib_subparsers.add_parser(
-            "sync", help="Sync library shows and process new episodes"
-        )
-        sync_parser.add_argument(
-            "--show", type=int, metavar="ID", help="Sync only specific show by ID"
-        )
-        sync_parser.add_argument("--dry-run", action="store_true", help="Preview only")
-        sync_parser.add_argument("--force", action="store_true", help="Reprocess episodes")
-        sync_parser.add_argument(
-            "--backfill", type=int, metavar="N", help="Override backfill limit"
-        )
-        sync_parser.add_argument("--output-dir", dest="output_dir", help="Output directory")
-        sync_parser.add_argument(
-            "--whisper-model",
-            dest="whisper_model",
-            default=WHISPER_MODEL,
-            help="Whisper model path",
-        )
-        sync_parser.add_argument("--groq-api-key", dest="groq_api_key", help="Groq API key")
-        sync_parser.add_argument(
-            "--analysis-type",
-            dest="analysis_type",
-            default="executive_summary",
-            help="Analysis type",
-        )
-        sync_parser.add_argument("--prompts-file", dest="prompts_file", help="Prompts file path")
-        sync_parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
-        sync_parser.add_argument("--no-digest", action="store_true", help="Skip digest generation")
-
-        # Digest command
-        digest_parser = lib_subparsers.add_parser("digest", help="Generate podcast digest")
-        digest_parser.add_argument("--date", help="Specific date (YYYY-MM-DD)")
-        digest_parser.add_argument("--range", help="Date range (e.g., 7d)")
-        digest_parser.add_argument("--output-dir", dest="output_dir", help="Output directory")
-        digest_parser.add_argument("--groq-api-key", dest="groq_api_key", help="Groq API key")
-        digest_parser.add_argument("--prompts-file", dest="prompts_file", help="Prompts file path")
-        digest_parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
-
-    # Input source group (mutually exclusive) - for original workflow
-    input_group = parser.add_mutually_exclusive_group(required=False)
-    input_group.add_argument(
-        "input_source", nargs="?", help="YouTube video URL or path to local audio file"
-    )
-    input_group.add_argument(
-        "--analyze-existing",
-        dest="analyze_existing",
-        help="Path to existing transcript file (.md or .txt) to analyze without re-transcribing",
-    )
-    input_group.add_argument(
-        "--diarize-existing",
-        dest="diarize_existing",
-        help="Path to existing transcript (.md) to run speaker diarization on. "
-        "Requires .whisper.json next to the transcript (auto-saved during transcription).",
-    )
-    parser.add_argument(
-        "--audio",
+    g.add_argument(
+        "-p",
+        "--preset",
         default=None,
-        help="Path to audio file for --diarize-existing (overrides auto-detected .wav).",
+        help="Use a named preset from config.yaml (e.g., 'daily'). Explicit flags override it.",
     )
-    parser.add_argument(
+    parents["global"] = g
+
+    # --- output --------------------------------------------------------------
+    o = argparse.ArgumentParser(add_help=False)
+    o.add_argument(
         "--output-dir",
         dest="output_dir",
         default=None,
         help="Output directory for Markdown files (default: config.yaml output_dir, "
-        "else the XDG data dir's transcripts/; see 'pidcast paths')",
+        "else the XDG data dir's transcripts/; see 'pidcast info')",
     )
-    parser.add_argument(
+    o.add_argument(
         "-o",
         "--save-to-obsidian",
         dest="save_to_obsidian",
         action="store_true",
-        help=f"Save analysis files to Obsidian vault (transcripts still saved to --output-dir) at: {OBSIDIAN_PATH}",
+        help=f"Save analysis files to Obsidian vault at: {OBSIDIAN_PATH}",
     )
-    parser.add_argument(
+    o.add_argument(
+        "--save",
+        action="store_true",
+        help="Save analysis output to file (default: terminal only)",
+    )
+    o.add_argument(
+        "--front-matter",
+        dest="front_matter",
+        default="{}",
+        help="JSON string for Markdown front matter",
+    )
+    o.add_argument(
+        "--tags",
+        default=None,
+        help="Comma-separated tags for front matter (overrides auto-inferred source tags).",
+    )
+    o.add_argument(
+        "--stats-file",
+        dest="stats_file",
+        default=None,
+        help=f"File to store run history/statistics (default: {RUNS_FILE})",
+    )
+    o.add_argument(
+        "--keep-transcript",
+        dest="keep_transcript",
+        action="store_true",
+        help="Keep the .txt transcript file alongside the .md file",
+    )
+    o.add_argument(
+        "--keep-audio",
+        dest="keep_audio",
+        action="store_true",
+        help="Save the converted WAV audio file to the output directory",
+    )
+    parents["output"] = o
+
+    # --- analysis ------------------------------------------------------------
+    a = argparse.ArgumentParser(add_help=False)
+    a.add_argument(
+        "--no-analyze",
+        action="store_true",
+        dest="no_analyze",
+        help="Skip LLM analysis (default: analyze is enabled)",
+    )
+    a.add_argument(
+        "-a",
+        "--analysis-type",
+        dest="analysis_type",
+        default="executive_summary",
+        help="Analysis type/prompt template (default: executive_summary). "
+        "See 'pidcast list analyses'.",
+    )
+    a.add_argument(
+        "--prompts-file",
+        dest="prompts_file",
+        default=None,
+        help=f"Path to prompts YAML file (default: {DEFAULT_PROMPTS_FILE})",
+    )
+    a.add_argument(
+        "--groq-api-key",
+        dest="groq_api_key",
+        default=None,
+        help="Groq API key (default: GROQ_API_KEY environment variable)",
+    )
+    a.add_argument(
+        "-m",
+        "--groq-model",
+        dest="groq_model",
+        default=None,
+        help="Groq model for analysis (default: from config/models.yaml). "
+        "See 'pidcast list models'.",
+    )
+    a.add_argument(
+        "--skip-analysis-on-error",
+        dest="skip_analysis_on_error",
+        action="store_true",
+        help="Continue if analysis fails instead of aborting",
+    )
+    a.add_argument(
+        "--provider",
+        default="groq",
+        choices=["groq", "claude"],
+        help="LLM provider for analysis: 'groq' (default) or 'claude' (uses local Claude CLI)",
+    )
+    a.add_argument(
+        "--claude-model",
+        dest="claude_model",
+        default=None,
+        help="Claude model alias when --provider claude: 'sonnet' (default), 'opus', 'haiku'",
+    )
+    parents["analysis"] = a
+
+    # --- whisper / transcription ---------------------------------------------
+    w = argparse.ArgumentParser(add_help=False)
+    w.add_argument(
         "--whisper-model",
         dest="whisper_model",
         default=WHISPER_MODEL,
-        help="Whisper model name (e.g., 'medium', 'large-v3-turbo') or path to model file",
+        help="Whisper model name (e.g., 'large-v3-turbo') or path to model file",
     )
-    parser.add_argument(
+    w.add_argument(
         "-l",
         "--language",
         default=None,
         help="Language code for transcription (e.g., 'uk', 'en', 'de'). Default: auto-detect.",
     )
-    parser.add_argument(
+    w.add_argument(
         "--transcription-provider",
         dest="transcription_provider",
         choices=["whisper", "elevenlabs"],
         default="whisper",
         help="Transcription backend: whisper (local) or elevenlabs (cloud). Default: whisper.",
     )
-    parser.add_argument(
+    w.add_argument(
         "--diarize",
         action="store_true",
         default=False,
-        help="Run speaker diarization (whisper: pyannote.audio + HUGGINGFACE_TOKEN, elevenlabs: built-in)",
+        help="Run speaker diarization (whisper: pyannote.audio + HUGGINGFACE_TOKEN; "
+        "elevenlabs: built-in)",
     )
-    parser.add_argument(
+    w.add_argument(
         "--output-format",
         dest="output_format",
         default="otxt",
         help="Whisper output format (txt, vtt, srt, json). Prefix with 'o' for original filename.",
     )
 
-    # Whisper quality / anti-hallucination options (whisper provider only)
-    whisper_quality = parser.add_argument_group("Whisper Quality Options")
-    whisper_quality.add_argument(
-        "--vad",
-        action="store_true",
-        default=False,
-        help="Enable Voice Activity Detection to strip silence before decoding "
-        "(reduces hallucinations). Needs a Silero VAD model; no-ops with a warning "
-        "if none is found. See WHISPER_VAD_MODEL / 'pidcast doctor'.",
+    # Expert / tuning knobs. Hidden from the default --help; still settable and
+    # preset-supplied. Help text is SUPPRESSed to keep the surface slim.
+    w.add_argument("--vad", action="store_true", default=False, help=argparse.SUPPRESS)
+    w.add_argument("--vad-model", dest="vad_model", default=None, help=argparse.SUPPRESS)
+    w.add_argument(
+        "--vad-threshold", dest="vad_threshold", type=float, default=None, help=argparse.SUPPRESS
     )
-    whisper_quality.add_argument(
-        "--vad-model",
-        dest="vad_model",
-        default=None,
-        help="Path to a Silero VAD model (overrides WHISPER_VAD_MODEL and auto-detect).",
-    )
-    whisper_quality.add_argument(
-        "--vad-threshold",
-        dest="vad_threshold",
-        type=float,
-        default=None,
-        help="VAD speech-probability threshold (whisper -vt). Default: whisper's 0.50.",
-    )
-    whisper_quality.add_argument(
+    w.add_argument(
         "--no-speech-thold",
         dest="no_speech_thold",
         type=float,
         default=None,
-        help="No-speech threshold (whisper -nth). Default: whisper's 0.60. "
-        "Raise (e.g. 0.8) to reject more low-speech audio.",
+        help=argparse.SUPPRESS,
     )
-    whisper_quality.add_argument(
-        "--temperature",
-        type=float,
-        default=None,
-        help="Sampling temperature (whisper -tp). Default: whisper's 0.00.",
-    )
-    whisper_quality.add_argument(
+    w.add_argument("--temperature", type=float, default=None, help=argparse.SUPPRESS)
+    w.add_argument(
         "--no-fallback",
         dest="no_fallback",
         action="store_true",
         default=False,
-        help="Disable temperature fallback while decoding (whisper -nf).",
+        help=argparse.SUPPRESS,
     )
-    whisper_quality.add_argument(
+    w.add_argument(
         "--suppress-nst",
         "--no-suppress-nst",
         dest="suppress_nst",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="Suppress non-speech tokens (whisper -sns). On by default to curb "
-        "boilerplate hallucinations; use --no-suppress-nst to disable.",
+        help=argparse.SUPPRESS,
     )
-    whisper_quality.add_argument(
-        "--whisper-threads",
-        dest="whisper_threads",
-        type=int,
-        default=8,
-        help="Number of whisper decoding threads (whisper -t). Default: 8.",
+    w.add_argument(
+        "--whisper-threads", dest="whisper_threads", type=int, default=8, help=argparse.SUPPRESS
     )
-    parser.add_argument(
-        "--front-matter",
-        dest="front_matter",
-        default="{}",
-        help="JSON string for Markdown front matter",
-    )
-    parser.add_argument(
-        "--tags",
-        default=None,
-        help="Comma-separated tags for front matter (overrides auto-inferred source tags). "
-        "Example: --tags meeting,standup,weekly",
-    )
-    parser.add_argument(
-        "--stats-file",
-        dest="stats_file",
-        default=None,
-        help=f"File to store run history/statistics (default: {RUNS_FILE})",
-    )
-    parser.add_argument(
-        "--keep-transcript",
-        dest="keep_transcript",
-        action="store_true",
-        help="Keep the .txt transcript file alongside the .md file",
-    )
-    parser.add_argument(
-        "--keep-audio",
-        dest="keep_audio",
-        action="store_true",
-        help="Save the converted WAV audio file to the output directory",
-    )
+    parents["whisper"] = w
 
-    checkpoint_group = parser.add_argument_group("Checkpoint / Resume Options")
-    checkpoint_group.add_argument(
-        "--no-checkpoint",
-        dest="no_checkpoint",
-        action="store_true",
-        help="Disable resume checkpointing (one-shot transcription, no pause/resume).",
-    )
-    checkpoint_group.add_argument(
-        "--keep-checkpoint",
-        dest="keep_checkpoint",
-        action="store_true",
-        help="Keep the checkpoint directory after a successful run (default: delete).",
-    )
-    # Internal: set by `pidcast resume` to re-enter a specific job. Hidden from help.
-    parser.add_argument(
-        "--resume-job-id", dest="resume_job_id", default=None, help=argparse.SUPPRESS
-    )
-    parser.add_argument(
+    # --- download / cookies (transcribe + lib process) -----------------------
+    d = argparse.ArgumentParser(add_help=False)
+    d.add_argument(
         "--po-token",
         dest="po_token",
         default=None,
         help="PO Token for bypassing YouTube restrictions (format: 'client.type+TOKEN')",
     )
-    parser.add_argument(
+    d.add_argument(
         "--cookies-from-browser",
         default=None,
         help="Browser to extract cookies from (e.g., 'chrome', 'firefox', 'safari')",
     )
-    parser.add_argument(
-        "--cookies",
-        default=None,
-        help="Path to Netscape format cookies file",
-    )
-    parser.add_argument(
+    d.add_argument("--cookies", default=None, help="Path to Netscape format cookies file")
+    d.add_argument(
         "--chrome-profile",
         default=None,
         dest="chrome_profile",
         help="Chrome profile for cookie extraction (display name or directory name)",
     )
-    parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
-    parser.add_argument(
-        "--force",
-        "-f",
-        action="store_true",
-        help="Skip duplicate detection and force transcription",
-    )
+    parents["download"] = d
 
-    # Test segment arguments
-    segment_group = parser.add_argument_group("Test Segment Options")
-    segment_group.add_argument(
-        "--test-segment",
+    return parents
+
+
+def _add_lib_subparsers(lib_subparsers, parents) -> None:
+    """Wire the ``pidcast lib <command>`` tree."""
+    from .commands import lib as lib_cmds
+
+    g = parents["global"]
+
+    add_p = lib_subparsers.add_parser("add", parents=[g], help="Add podcast to library")
+    add_p.add_argument("feed_url", help="RSS feed URL or podcast name to search for")
+    add_p.add_argument("--preview", action="store_true", help="Preview episodes before adding")
+    add_p.set_defaults(func=lib_cmds.handle_add)
+
+    list_p = lib_subparsers.add_parser("list", parents=[g], help="List all shows in library")
+    list_p.set_defaults(func=lib_cmds.handle_list)
+
+    show_p = lib_subparsers.add_parser("show", parents=[g], help="Show details for a podcast")
+    show_p.add_argument("show_id", type=int, help="Show ID")
+    show_p.add_argument(
+        "--episodes", type=int, default=5, help="Number of recent episodes to show (default: 5)"
+    )
+    show_p.set_defaults(func=lib_cmds.handle_show)
+
+    remove_p = lib_subparsers.add_parser("remove", parents=[g], help="Remove podcast from library")
+    remove_p.add_argument("show_id", type=int, help="Show ID")
+    remove_p.set_defaults(func=lib_cmds.handle_remove)
+
+    process_p = lib_subparsers.add_parser(
+        "process",
+        parents=[
+            g,
+            parents["whisper"],
+            parents["analysis"],
+            parents["output"],
+            parents["download"],
+        ],
+        help="Process an episode from a library show",
+    )
+    process_p.add_argument("show_query", help="Show ID or partial name")
+    process_p.add_argument("--latest", action="store_true", help="Process the latest episode")
+    process_p.add_argument("--match", help="Process episode matching this title string")
+    process_p.set_defaults(func=lib_cmds.handle_process)
+
+    sync_p = lib_subparsers.add_parser(
+        "sync",
+        parents=[g, parents["whisper"], parents["analysis"], parents["output"]],
+        help="Sync library shows and process new episodes",
+    )
+    sync_p.add_argument("--show", type=int, metavar="ID", help="Sync only specific show by ID")
+    sync_p.add_argument("--dry-run", action="store_true", help="Preview only")
+    sync_p.add_argument("--backfill", type=int, metavar="N", help="Override backfill limit")
+    sync_p.add_argument("--no-digest", action="store_true", help="Skip digest generation")
+    sync_p.set_defaults(func=lib_cmds.handle_sync)
+
+    digest_p = lib_subparsers.add_parser(
+        "digest",
+        parents=[g, parents["analysis"], parents["output"]],
+        help="Generate podcast digest",
+    )
+    digest_p.add_argument("--date", help="Specific date (YYYY-MM-DD)")
+    digest_p.add_argument("--range", help="Date range (e.g., 7d)")
+    digest_p.set_defaults(func=lib_cmds.handle_digest)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Construct the full verb-first parser (unconditional subparser tree)."""
+    from .commands.analyze import cmd_analyze
+    from .commands.diarize import cmd_diarize
+    from .commands.info import cmd_info
+    from .commands.listing import cmd_list
+    from .commands.transcribe import cmd_transcribe
+    from .resume import run_resume
+    from .setup import run_doctor, run_setup
+
+    parents = _build_parent_parsers()
+
+    parser = argparse.ArgumentParser(
+        prog="pidcast",
+        description="Turn a URL or audio file into an Obsidian-ready transcript with LLM analysis.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Common workflows:
+  pidcast "https://youtube.com/watch?v=ID"          Transcribe + analyze (bare = transcribe)
+  pidcast transcribe FILE.mp3 -o -a exec            Save to Obsidian, executive summary
+  pidcast transcribe FILE.mp3 --test 5 --start-at 10  Dry-run a 5-min slice from 10:00
+  pidcast analyze transcript.md -a summary          Re-analyze an existing transcript
+  pidcast diarize transcript.md                     Retry diarization only
+  pidcast list models                               Discover analyses/models/presets/...
+  pidcast lib add "Lex Fridman"                     Manage the podcast library
+""",
+    )
+    sub = parser.add_subparsers(dest="command", metavar="<command>")
+
+    # --- transcribe (also the bare-input default) ----------------------------
+    t = sub.add_parser(
+        "transcribe",
+        parents=[
+            parents["global"],
+            parents["whisper"],
+            parents["analysis"],
+            parents["output"],
+            parents["download"],
+        ],
+        help="Transcribe a URL or audio file (and analyze)",
+    )
+    t.add_argument("input", help="YouTube/podcast URL or path to a local audio file")
+    t.add_argument(
+        "--test",
         nargs="?",
         const=2,
         type=float,
         default=None,
         dest="test_segment",
         metavar="MINUTES",
-        help="Test transcription settings on first N minutes of audio (default: 2). "
-        "Skips markdown creation, analysis, and statistics.",
+        help="Dry-run transcription on the first N minutes (default: 2). "
+        "Skips markdown, analysis, and stats.",
     )
-    segment_group.add_argument(
+    t.add_argument(
         "--start-at",
         type=float,
         default=None,
         dest="start_at",
         metavar="MINUTES",
-        help="Start offset in minutes for --test-segment (default: 0). "
-        "Use to skip intros or jump to a specific section.",
+        help="Start offset in minutes for --test (default: 0).",
     )
-
-    # LLM Analysis arguments
-    analysis_group = parser.add_argument_group("LLM Analysis Options")
-    analysis_group.add_argument(
-        "--no-analyze",
+    # Checkpoint / resume options.
+    t.add_argument(
+        "--no-checkpoint",
+        dest="no_checkpoint",
         action="store_true",
-        dest="no_analyze",
-        help="Skip LLM analysis (default: analyze is enabled)",
+        help="Disable resume checkpointing (one-shot transcription).",
     )
-    analysis_group.add_argument(
-        "-a",
-        "--analysis-type",
-        dest="analysis_type",
-        default="executive_summary",
-        help="Analysis type/prompt template to use (default: executive_summary). Use -L to list available types.",
-    )
-    analysis_group.add_argument(
-        "--prompts-file",
-        dest="prompts_file",
-        default=None,
-        help=f"Path to prompts YAML file (default: {DEFAULT_PROMPTS_FILE})",
-    )
-    analysis_group.add_argument(
-        "--groq-api-key",
-        dest="groq_api_key",
-        default=None,
-        help="Groq API key (default: GROQ_API_KEY environment variable)",
-    )
-    analysis_group.add_argument(
-        "-m",
-        "--groq-model",
-        dest="groq_model",
-        default=None,
-        help="Groq model to use for analysis (default: from config/models.yaml). Use -M to list available models.",
-    )
-    analysis_group.add_argument(
-        "--skip-analysis-on-error",
-        dest="skip_analysis_on_error",
+    t.add_argument(
+        "--keep-checkpoint",
+        dest="keep_checkpoint",
         action="store_true",
-        help="Continue if analysis fails instead of aborting",
+        help="Keep the checkpoint directory after a successful run (default: delete).",
     )
-    analysis_group.add_argument(
-        "--provider",
-        default="groq",
-        choices=["groq", "claude"],
-        help="LLM provider for analysis: 'groq' (default) or 'claude' (uses local Claude CLI)",
-    )
-    analysis_group.add_argument(
-        "--claude-model",
-        dest="claude_model",
-        default=None,
-        help="Claude model alias when --provider claude: 'sonnet' (default), 'opus', 'haiku'",
-    )
+    # Internal: set by `pidcast resume` to re-enter a specific job.
+    t.add_argument("--resume-job-id", dest="resume_job_id", default=None, help=argparse.SUPPRESS)
+    t.set_defaults(func=cmd_transcribe)
 
-    # Output options
-    output_group = parser.add_argument_group("Output Options")
-    output_group.add_argument(
-        "--save",
+    # --- analyze -------------------------------------------------------------
+    an = sub.add_parser(
+        "analyze",
+        parents=[parents["global"], parents["analysis"], parents["output"]],
+        help="Analyze an existing transcript without re-transcribing",
+    )
+    an.add_argument("transcript", help="Path to an existing transcript (.md or .txt)")
+    an.set_defaults(func=cmd_analyze)
+
+    # --- diarize -------------------------------------------------------------
+    di = sub.add_parser(
+        "diarize",
+        parents=[parents["global"]],
+        help="Run speaker diarization on an existing transcript",
+    )
+    di.add_argument("transcript", help="Path to an existing transcript (.md). Needs .whisper.json.")
+    di.add_argument(
+        "--audio", default=None, help="Path to audio file (overrides auto-detected .wav)."
+    )
+    di.set_defaults(func=cmd_diarize)
+
+    # --- list ----------------------------------------------------------------
+    li = sub.add_parser(
+        "list", parents=[parents["global"]], help="List analyses/models/presets/..."
+    )
+    li.add_argument(
+        "thing",
+        choices=["analyses", "models", "whisper-models", "presets", "profiles"],
+        help="What to list",
+    )
+    li.set_defaults(func=cmd_list)
+
+    # --- lib -----------------------------------------------------------------
+    lib_p = sub.add_parser("lib", help="Podcast library management")
+    lib_sub = lib_p.add_subparsers(dest="lib_command", metavar="<lib-command>", required=True)
+    _add_lib_subparsers(lib_sub, parents)
+
+    # --- setup / doctor / resume / info --------------------------------------
+    su = sub.add_parser("setup", parents=[parents["global"]], help="Interactive setup wizard")
+    su.set_defaults(func=run_setup)
+
+    do = sub.add_parser("doctor", parents=[parents["global"]], help="Diagnose tooling/env config")
+    do.add_argument(
+        "--prune-stats",
+        dest="prune_stats",
         action="store_true",
-        help="Save analysis output to file (default: terminal only)",
+        help="Remove phantom stats entries with a missing transcript",
     )
+    do.set_defaults(func=run_doctor)
 
-    # Discoverability options
-    discovery_group = parser.add_argument_group("Discovery Options")
-    discovery_group.add_argument(
-        "-L",
-        "--list-analyses",
-        action="store_true",
-        dest="list_analyses",
-        help="List available analysis types and exit",
+    re = sub.add_parser("resume", parents=[parents["global"]], help="Resume a paused transcription")
+    re.add_argument("job_id", nargs="?", default=None, help="Job id to resume (optional)")
+    re.set_defaults(func=run_resume)
+
+    inf = sub.add_parser(
+        "info", parents=[parents["global"]], help="Show resolved data/config paths"
     )
-    discovery_group.add_argument(
-        "-M",
-        "--list-models",
-        action="store_true",
-        dest="list_models",
-        help="List available Groq models and exit",
-    )
-    discovery_group.add_argument(
-        "-W",
-        "--list-whisper-models",
-        action="store_true",
-        dest="list_whisper_models",
-        help="List available Whisper models and exit",
-    )
-    discovery_group.add_argument(
-        "--list-chrome-profiles",
-        action="store_true",
-        dest="list_chrome_profiles",
-        help="List available Chrome profiles for cookie extraction and exit",
-    )
+    inf.set_defaults(func=cmd_info)
 
-    # Preset options
-    preset_group = parser.add_argument_group("Preset Options")
-    preset_group.add_argument(
-        "-p",
-        "--preset",
-        default=None,
-        help="Use a named preset from config.yaml (e.g., 'daily', 'meeting'). "
-        "Explicit flags override preset values. Use -P to list presets.",
-    )
-    preset_group.add_argument(
-        "-P",
-        "--list-presets",
-        action="store_true",
-        dest="list_presets",
-        help="List available presets and exit",
-    )
+    return parser
 
-    return parser.parse_args()
 
+def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
 
-# ============================================================================
-# LIBRARY COMMAND HANDLERS
-# ============================================================================
+    Args:
+        argv: Explicit argument list (without prog). Defaults to ``sys.argv[1:]``.
 
-
-def cmd_process(args: argparse.Namespace) -> None:
-    """Handle 'pidcast lib process' command."""
-    import uuid
-
-    from .config import OBSIDIAN_PATH, VideoInfo
-    from .library import LibraryManager, Show
-
-    library = LibraryManager()
-
-    # Find show
-    show_query = args.show_query
-    show: Show | None = None
-
-    # Try as ID
-    try:
-        show_id = int(show_query)
-        show = library.get_show(show_id)
-    except ValueError:
-        pass
-
-    # Try as name (case insensitive partial match)
-    if not show:
-        matches = [s for s in library.list_shows() if show_query.lower() in s.title.lower()]
-        if len(matches) == 1:
-            show = matches[0]
-        elif len(matches) > 1:
-            print(f"Ambiguous show name '{show_query}'. Matches:")
-            for s in matches:
-                print(f"  {s.id}: {s.title}")
-            return
-
-    if not show:
-        log_error(f"Show '{show_query}' not found.")
-        return
-
-    # Fetch episodes
-    episodes = library.get_episodes(show.id, limit=50 if args.match else 20, verbose=args.verbose)
-
-    selected_episode = None
-
-    if args.latest:
-        selected_episode = episodes[0] if episodes else None
-    elif args.match:
-        # fuzzy match title
-        query = args.match.lower()
-        for ep in episodes:
-            if query in ep.title.lower():
-                selected_episode = ep
-                break
-        if not selected_episode:
-            log_error(f"No episode found matching '{args.match}'")
-            return
-    else:
-        # Interactive selection
-        try:
-            from rich.console import Console
-            from rich.prompt import Prompt
-            from rich.table import Table
-
-            console = Console()
-
-            table = Table(show_header=True)
-            table.add_column("#", style="cyan", width=4)
-            table.add_column("Date", style="yellow", width=12)
-            table.add_column("Title", style="white")
-
-            # Show top 10
-            display_episodes = episodes[:10]
-            for i, ep in enumerate(display_episodes, 1):
-                table.add_row(str(i), ep.pub_date.strftime("%Y-%m-%d"), ep.title)
-
-            console.print(table)
-
-            # Ask for selection
-            choices = [str(i) for i in range(1, len(display_episodes) + 1)]
-            choice = Prompt.ask("Select episode", choices=choices)
-            selected_episode = display_episodes[int(choice) - 1]
-        except ImportError:
-            # Fallback
-            print("Rich not installed, and no selection flags used. Defaulting to latest.")
-            selected_episode = episodes[0] if episodes else None
-
-    if not selected_episode:
-        log_error("No episodes found.")
-        return
-
-    logger.info(f"\nProcessing: {selected_episode.title} ({show.title})")
-
-    # Construct override
-    video_info = VideoInfo(
-        title=selected_episode.title,
-        webpage_url=selected_episode.audio_url,
-        channel=show.title,
-        upload_date=selected_episode.pub_date.strftime("%Y%m%d"),
-        description=selected_episode.description,
-        duration=selected_episode.duration or 0,
-    )
-
-    # Resolve whisper model
-    if args.whisper_model:
-        from .transcription import resolve_whisper_model
-
-        try:
-            args.whisper_model = resolve_whisper_model(args.whisper_model)
-        except Exception as e:
-            log_error(str(e))
-            return
-
-    # Run workflow
-    output_dir = resolve_output_dir(args)
-    stats_file = Path(args.stats_file) if args.stats_file else RUNS_FILE
-    analysis_output_dir = Path(OBSIDIAN_PATH) if args.save_to_obsidian else output_dir
-
-    process_input_source(
-        selected_episode.audio_url,
-        args,
-        output_dir,
-        analysis_output_dir,
-        stats_file,
-        str(uuid.uuid4()),
-        datetime.datetime.now().isoformat(),
-        time.time(),
-        video_info_override=video_info,
-    )
-
-
-def cmd_add(args: argparse.Namespace) -> None:
-    """Handle 'pidcast add' command."""
-    from .config_manager import ConfigManager
-    from .library import LibraryManager
-    from .rss import RSSParser
-
-    try:
-        from rich.console import Console
-        from rich.prompt import Confirm
-        from rich.table import Table
-
-        has_rich = True
-    except ImportError:
-        has_rich = False
-
-    # Initialize config and library
-    ConfigManager.init_default_config()
-    library = LibraryManager()
-
-    # Resolve feed URL from name if user didn't pass a URL
-    feed_url = args.feed_url
-    if not feed_url.startswith(("http://", "https://", "feed://")):
-        from .discovery import discover_podcast, prompt_user_selection
-
-        query = feed_url
-        if has_rich:
-            Console().print(f"\nSearching for podcasts matching [bold]{query!r}[/bold]...")
-        else:
-            print(f"\nSearching for podcasts matching {query!r}...")
-
-        results = discover_podcast(query)
-        if not results:
-            log_error(f"No podcasts found for {query!r}. Try using the RSS feed URL directly.")
-            return
-
-        chosen = prompt_user_selection(results)
-        if chosen is None:
-            logger.info("Cancelled.")
-            return
-
-        feed_url = chosen["feed_url"]
-        args.feed_url = feed_url
-
-    try:
-        # Preview mode: show episodes before adding
-        if args.preview:
-            if args.verbose:
-                logger.info(f"Fetching feed preview: {args.feed_url}")
-
-            show_meta, episodes = RSSParser.parse_feed(args.feed_url, verbose=args.verbose)
-
-            if has_rich:
-                console = Console()
-                console.print(f"\n[bold cyan]Show:[/bold cyan] {show_meta['title']}")
-                console.print(f"[bold cyan]Author:[/bold cyan] {show_meta['author']}")
-                console.print("\n[bold]Recent Episodes:[/bold]")
-
-                table = Table(show_header=True)
-                table.add_column("#", style="cyan", width=4)
-                table.add_column("Date", style="yellow", width=12)
-                table.add_column("Title", style="white")
-
-                for i, episode in enumerate(episodes[:5], 1):
-                    date_str = episode.pub_date.strftime("%Y-%m-%d")
-                    table.add_row(str(i), date_str, episode.title)
-
-                console.print(table)
-                console.print(f"\nTotal episodes: {len(episodes)}")
-
-                if not Confirm.ask("\nAdd this show to library?", default=True):
-                    logger.info("Cancelled.")
-                    return
-            else:
-                print(f"\nShow: {show_meta['title']}")
-                print(f"Author: {show_meta['author']}")
-                print("\nRecent Episodes:")
-                for i, episode in enumerate(episodes[:5], 1):
-                    print(f"  {i}. {episode}")
-                print(f"\nTotal episodes: {len(episodes)}")
-
-                confirm = input("\nAdd this show to library? [Y/n]: ").strip().lower()
-                if confirm and confirm not in ["y", "yes"]:
-                    logger.info("Cancelled.")
-                    return
-
-        # Add show to library
-        show = library.add_show(args.feed_url, verbose=args.verbose)
-
-        if has_rich:
-            console = Console()
-            console.print(f"\n[green]✓[/green] Added: [bold]{show.title}[/bold] (ID: {show.id})")
-        else:
-            print(f"\n✓ Added: {show.title} (ID: {show.id})")
-
-    except DuplicateShowError as e:
-        log_error(str(e))
-    except (FeedFetchError, FeedParseError) as e:
-        log_error(f"Failed to add show: {e}")
-        if args.verbose:
-            traceback.print_exc()
-    except Exception as e:
-        log_error(f"An unexpected error occurred: {e}")
-        if args.verbose:
-            traceback.print_exc()
-
-
-def cmd_list(args: argparse.Namespace) -> None:
-    """Handle 'pidcast list' command."""
-    from .library import LibraryManager
-
-    try:
-        from rich.console import Console
-        from rich.table import Table
-
-        has_rich = True
-    except ImportError:
-        has_rich = False
-
-    # Initialize library
-    library = LibraryManager()
-    shows = library.list_shows()
-
-    if not shows:
-        logger.info("No shows in library. Use 'pidcast add <feed-url>' to add shows.")
-        return
-
-    if has_rich:
-        console = Console()
-        table = Table(show_header=True, title=f"Podcast Library ({len(shows)} shows)")
-        table.add_column("ID", style="cyan", width=4)
-        table.add_column("Title", style="white")
-        table.add_column("Author", style="yellow")
-        table.add_column("Added", style="dim", width=12)
-
-        for show in shows:
-            added_str = show.added_at.strftime("%Y-%m-%d")
-            table.add_row(str(show.id), show.title, show.author or "Unknown", added_str)
-
-        console.print(table)
-    else:
-        print(f"\nPodcast Library ({len(shows)} shows):")
-        print("-" * 80)
-        for show in shows:
-            added_str = show.added_at.strftime("%Y-%m-%d")
-            print(f"ID: {show.id}")
-            print(f"  Title: {show.title}")
-            print(f"  Author: {show.author or 'Unknown'}")
-            print(f"  Added: {added_str}")
-            print()
-
-
-def cmd_show(args: argparse.Namespace) -> None:
-    """Handle 'pidcast show' command."""
-    from .library import LibraryManager
-
-    try:
-        from rich.console import Console
-        from rich.panel import Panel
-        from rich.table import Table
-
-        has_rich = True
-    except ImportError:
-        has_rich = False
-
-    # Initialize library
-    library = LibraryManager()
-
-    try:
-        show = library.get_show(args.show_id)
-        if not show:
-            log_error(
-                f"Show ID {args.show_id} not found. Run 'pidcast list' to see available shows."
-            )
-            return
-
-        # Fetch episodes
-        episodes = library.get_episodes(args.show_id, limit=args.episodes, verbose=args.verbose)
-
-        if has_rich:
-            console = Console()
-
-            # Show metadata
-            info_table = Table(show_header=False, box=None, padding=(0, 2))
-            info_table.add_column(style="cyan bold", width=15)
-            info_table.add_column(style="white")
-
-            info_table.add_row("ID", str(show.id))
-            info_table.add_row("Title", show.title)
-            info_table.add_row("Author", show.author or "Unknown")
-            info_table.add_row("Feed URL", show.feed_url)
-            info_table.add_row("Added", show.added_at.strftime("%Y-%m-%d %H:%M"))
-            if show.last_checked:
-                info_table.add_row("Last Checked", show.last_checked.strftime("%Y-%m-%d %H:%M"))
-
-            console.print(
-                Panel(info_table, title=f"[bold]{show.title}[/bold]", border_style="cyan")
-            )
-
-            # Episodes
-            console.print(f"\n[bold]Recent Episodes (showing {len(episodes)}):[/bold]")
-            ep_table = Table(show_header=True)
-            ep_table.add_column("#", style="cyan", width=4)
-            ep_table.add_column("Date", style="yellow", width=12)
-            ep_table.add_column("Duration", style="dim", width=10)
-            ep_table.add_column("Title", style="white")
-
-            for i, episode in enumerate(episodes, 1):
-                date_str = episode.pub_date.strftime("%Y-%m-%d")
-                duration_str = f"{episode.duration // 60}m" if episode.duration else "Unknown"
-                ep_table.add_row(str(i), date_str, duration_str, episode.title)
-
-            console.print(ep_table)
-        else:
-            print(f"\n{'=' * 80}")
-            print(f"Show Details (ID: {show.id})")
-            print(f"{'=' * 80}")
-            print(f"Title: {show.title}")
-            print(f"Author: {show.author or 'Unknown'}")
-            print(f"Feed URL: {show.feed_url}")
-            print(f"Added: {show.added_at.strftime('%Y-%m-%d %H:%M')}")
-            if show.last_checked:
-                print(f"Last Checked: {show.last_checked.strftime('%Y-%m-%d %H:%M')}")
-
-            print(f"\nRecent Episodes (showing {len(episodes)}):")
-            print("-" * 80)
-            for i, episode in enumerate(episodes, 1):
-                print(f"{i}. {episode}")
-            print()
-
-    except ShowNotFoundError as e:
-        log_error(str(e))
-    except (FeedFetchError, FeedParseError) as e:
-        log_error(f"Failed to fetch episodes: {e}")
-        if args.verbose:
-            traceback.print_exc()
-    except Exception as e:
-        log_error(f"An unexpected error occurred: {e}")
-        if args.verbose:
-            traceback.print_exc()
-
-
-def cmd_remove(args: argparse.Namespace) -> None:
-    """Handle 'pidcast remove' command."""
-    from .library import LibraryManager
-
-    try:
-        from rich.console import Console
-
-        has_rich = True
-    except ImportError:
-        has_rich = False
-
-    # Initialize library
-    library = LibraryManager()
-
-    # Get show details before removing
-    show = library.get_show(args.show_id)
-    if not show:
-        log_error(f"Show ID {args.show_id} not found. Run 'pidcast list' to see available shows.")
-        return
-
-    # Remove show
-    if library.remove_show(args.show_id):
-        if has_rich:
-            console = Console()
-            console.print(f"\n[green]✓[/green] Removed: [bold]{show.title}[/bold] (ID: {show.id})")
-        else:
-            print(f"\n✓ Removed: {show.title} (ID: {show.id})")
-    else:
-        log_error(f"Failed to remove show ID {args.show_id}")
-
-
-def cmd_digest(args: argparse.Namespace) -> None:
-    """Handle 'pidcast digest' command."""
-    from datetime import datetime, timedelta
-
-    from .config import DEFAULT_PROMPTS_FILE, HISTORY_FILE, get_digest_output_path
-    from .digest import DigestFormatter, DigestGenerator
-    from .history import ProcessingHistory
-    from .library import LibraryManager
-    from .summarization import Summarizer
-
-    # Get Groq API key
-    groq_api_key = args.groq_api_key or os.environ.get("GROQ_API_KEY")
-    if not groq_api_key:
-        log_error(
-            "Groq API key not found. Set GROQ_API_KEY environment variable or use --groq_api_key"
-        )
-        return
-
-    # Initialize components
-    library = LibraryManager()
-    history = ProcessingHistory(HISTORY_FILE)
-    prompts_file = Path(args.prompts_file) if args.prompts_file else DEFAULT_PROMPTS_FILE
-    summarizer = Summarizer(prompts_file, groq_api_key)
-
-    generator = DigestGenerator(library, history, summarizer)
-
-    # Parse date filters
-    date_filter = None
-    date_range = None
-
-    if args.date:
-        try:
-            date_filter = datetime.strptime(args.date, "%Y-%m-%d")
-        except ValueError:
-            log_error(f"Invalid date format: {args.date}. Use YYYY-MM-DD format.")
-            return
-    elif args.range:
-        # Parse range like "7d", "30d"
-        try:
-            if args.range.endswith("d"):
-                days = int(args.range[:-1])
-                date_range = timedelta(days=days)
-            else:
-                log_error(f"Invalid range format: {args.range}. Use format like '7d' or '30d'.")
-                return
-        except ValueError:
-            log_error(f"Invalid range format: {args.range}. Use format like '7d' or '30d'.")
-            return
-    else:
-        # Default: today's episodes
-        date_filter = datetime.now()
-
-    # Generate digest
-    try:
-        logger.info("Generating digest...")
-        digest = generator.generate_digest(date_filter, date_range)
-
-        if not digest.episodes:
-            logger.info("No episodes found for specified date range.")
-            return
-
-        # Display in terminal
-        DigestFormatter.format_terminal(digest)
-
-        # Save to file (digest path comes from DIGESTS_DIR via get_digest_output_path)
-        output_dir = resolve_output_dir(args)
-        output_dir.mkdir(parents=True, exist_ok=True)
-        output_path = get_digest_output_path(date_filter or datetime.now())
-
-        markdown = DigestFormatter.format_markdown(digest)
-        with open(output_path, "w", encoding="utf-8") as f:
-            f.write(markdown)
-
-        logger.info(f"\nDigest saved to: {output_path}")
-
-    except Exception as e:
-        log_error(f"Failed to generate digest: {e}")
-        if args.verbose:
-            traceback.print_exc()
-
-
-def cmd_sync(args: argparse.Namespace) -> None:
-    """Handle 'pidcast sync' command."""
-    from .config import DEFAULT_BACKFILL_LIMIT, HISTORY_FILE, WHISPER_MODEL
-    from .history import ProcessingHistory
-    from .library import LibraryManager
-    from .sync import SyncEngine
-
-    # Initialize library and history
-    library = LibraryManager()
-    history = ProcessingHistory(HISTORY_FILE)
-
-    # Get output directory
-    output_dir = resolve_output_dir(args)
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    # Get Whisper model
-    whisper_model = args.whisper_model or WHISPER_MODEL
-    if not whisper_model:
-        log_error(
-            "Whisper model not specified. Set WHISPER_MODEL environment variable "
-            "or use --whisper_model flag"
-        )
-        return
-
-    # Resolve model name to path
-    from .transcription import resolve_whisper_model
-
-    try:
-        whisper_model = resolve_whisper_model(whisper_model)
-    except Exception as e:
-        log_error(str(e))
-        return
-
-    # Get Groq API key (optional)
-    groq_api_key = args.groq_api_key or os.environ.get("GROQ_API_KEY")
-
-    # Build config
-    config = {
-        "backfill_limit": DEFAULT_BACKFILL_LIMIT,
-    }
-
-    # Create sync engine
-    engine = SyncEngine(
-        library=library,
-        history=history,
-        config=config,
-        output_dir=output_dir,
-        whisper_model=whisper_model,
-        groq_api_key=groq_api_key,
-        analysis_type=args.analysis_type,
-        prompts_file=Path(args.prompts_file) if args.prompts_file else None,
-        verbose=args.verbose,
-    )
-
-    # Run sync
-    try:
-        stats = engine.sync(
-            show_id=args.show,
-            dry_run=args.dry_run,
-            force=args.force,
-            backfill=args.backfill,
-        )
-
-        # Print summary
-        logger.info(f"\n{'=' * 60}")
-        logger.info("Sync Complete!")
-        logger.info(f"{'=' * 60}")
-        logger.info(f"Processed: {stats['processed']} episodes")
-        logger.info(f"Succeeded: {stats['succeeded']}")
-        logger.info(f"Failed: {stats['failed']}")
-        if stats["skipped"] > 0:
-            logger.info(f"Skipped: {stats['skipped']} (already processed)")
-        logger.info(f"{'=' * 60}\n")
-
-        # Generate digest unless --no-digest flag is set
-        if not args.no_digest and stats["succeeded"] > 0 and groq_api_key:
-            from datetime import datetime
-
-            from .config import get_digest_output_path
-            from .digest import DigestFormatter, DigestGenerator
-            from .summarization import Summarizer
-
-            try:
-                logger.info("Generating digest...")
-                prompts_file = (
-                    Path(args.prompts_file) if args.prompts_file else DEFAULT_PROMPTS_FILE
-                )
-                summarizer = Summarizer(prompts_file, groq_api_key)
-                digest_generator = DigestGenerator(library, history, summarizer)
-
-                # Generate digest for today's processed episodes
-                digest = digest_generator.generate_digest(date_filter=datetime.now())
-
-                if digest.episodes:
-                    DigestFormatter.format_terminal(digest)
-
-                    # Save digest
-                    output_path = get_digest_output_path(datetime.now())
-                    markdown = DigestFormatter.format_markdown(digest)
-                    with open(output_path, "w", encoding="utf-8") as f:
-                        f.write(markdown)
-
-                    logger.info(f"\n✓ Digest saved to: {output_path}")
-
-            except Exception as e:
-                logger.warning(f"Failed to generate digest: {e}")
-                if args.verbose:
-                    traceback.print_exc()
-
-    except Exception as e:
-        log_error(f"Sync failed: {e}")
-        if args.verbose:
-            traceback.print_exc()
-
-
-def cmd_doctor(prune_stats: bool = False) -> None:
-    """Run health checks and display configuration status."""
-    from .config import RUNS_FILE
-    from .setup import determine_status, run_all_checks
-    from .utils import prune_phantom_stats
-
-    print("\npidcast doctor")
-    print("=" * 40)
-
-    if prune_stats:
-        removed = prune_phantom_stats(RUNS_FILE)
-        print(f"  Pruned {removed} phantom stats entr(y/ies) with a missing transcript.\n")
-
-    checks = run_all_checks()
-    max_name = max(len(c.name) for c in checks)
-
-    for check in checks:
-        dots = "." * (max_name + 6 - len(check.name))
-        if check.ok:
-            print(f"  {check.name} {dots} {check.detail}")
-        else:
-            label = "MISSING" if check.required else "not set"
-            msg = check.detail if check.detail != "not set" else label
-            print(f"  {check.name} {dots} {msg}")
-            if check.hint:
-                print(f"    -> {check.hint}")
-
-    status, tip = determine_status(checks)
-    print(f"\n  Status: {status}")
-    if tip:
-        print(f"  Tip: {tip}")
-    print()
-
-
-def cmd_setup() -> None:
-    """Interactive setup wizard for first-time users."""
-
-    from .setup import (
-        ENV_FILE,
-        check_env_var,
-        check_ffmpeg,
-        check_vad_model,
-        check_whisper,
-        check_whisper_model,
-        write_env_var,
-    )
-
-    print("\npidcast setup")
-    print("=" * 40)
-
-    # Step 1: System dependencies
-    print("\nStep 1/3: Checking system dependencies...\n")
-
-    ffmpeg = check_ffmpeg()
-    if ffmpeg.ok:
-        print(f"  ffmpeg: {ffmpeg.detail}")
-    else:
-        print("  ffmpeg: not found")
-        print("    Install: brew install ffmpeg (macOS) or apt install ffmpeg (Linux)")
-        print("    Then re-run: pidcast setup")
-        return
-
-    whisper = check_whisper()
-    whisper_model = check_whisper_model()
-    use_elevenlabs = False
-
-    if whisper.ok and whisper_model.ok:
-        print(f"  whisper.cpp: {whisper.detail}")
-        print(f"  whisper model: {whisper_model.detail}")
-        vad = check_vad_model()
-        if vad.ok:
-            print(f"  VAD model: {vad.detail}")
-        else:
-            print("  VAD model: not found (optional, enables --vad anti-hallucination)")
-            print("    Download: cd whisper.cpp && bash models/download-vad-model.sh silero-v5.1.2")
-            print("    Then set in .env: WHISPER_VAD_MODEL=/path/to/ggml-silero-v5.1.2.bin")
-    else:
-        print("  whisper.cpp: not configured")
-        print("\n  whisper.cpp is needed for local (private) transcription.")
-        print("  You can skip it and use ElevenLabs (cloud) instead.\n")
-        print("  [1] I'll set up whisper.cpp myself (see README for instructions)")
-        print("  [2] Skip - use ElevenLabs cloud transcription")
-        try:
-            choice = input("\n  > ").strip()
-        except (EOFError, KeyboardInterrupt):
-            print("\n  Setup cancelled.")
-            return
-        if choice == "2":
-            use_elevenlabs = True
-        else:
-            print("\n  To set up whisper.cpp:")
-            print("    1. git clone https://github.com/ggerganov/whisper.cpp.git")
-            print("    2. cd whisper.cpp && make")
-            print("    3. bash models/download-ggml-model.sh base.en")
-            print("    4. Set in .env: WHISPER_CPP_PATH=/path/to/whisper.cpp/build/bin/whisper-cli")
-            print("    5. Set in .env: WHISPER_MODEL=/path/to/whisper.cpp/models/ggml-base.en.bin")
-            print("    6. Re-run: pidcast setup")
-            return
-
-    # Step 2: API keys
-    print("\nStep 2/3: API keys\n")
-
-    # Groq (for analysis)
-    groq = check_env_var("GROQ_API_KEY", "GROQ_API_KEY")
-    if groq.ok:
-        print(f"  GROQ_API_KEY: {groq.detail}")
-    else:
-        print("  GROQ_API_KEY: not set (needed for AI analysis)")
-        print("  Get a free key at: https://console.groq.com/")
-        try:
-            key = input("  Paste your key (or press Enter to skip): ").strip()
-        except (EOFError, KeyboardInterrupt):
-            key = ""
-        if key:
-            write_env_var("GROQ_API_KEY", key)
-            print("  Saved to .env")
-        else:
-            print("  Skipped - transcription will work, but AI analysis will be disabled")
-
-    # ElevenLabs (if chosen or if no whisper)
-    if use_elevenlabs:
-        el = check_env_var("ELEVENLABS_API_KEY", "ELEVENLABS_API_KEY")
-        if el.ok:
-            print(f"  ELEVENLABS_API_KEY: {el.detail}")
-        else:
-            print("\n  ELEVENLABS_API_KEY: not set (needed for cloud transcription)")
-            print("  Get a key at: https://elevenlabs.io/")
-            try:
-                key = input("  Paste your key: ").strip()
-            except (EOFError, KeyboardInterrupt):
-                key = ""
-            if key:
-                write_env_var("ELEVENLABS_API_KEY", key)
-                print("  Saved to .env")
-            else:
-                print("  Without this key, transcription won't work.")
-                print("  Add it to .env later: ELEVENLABS_API_KEY=your_key")
-                return
-
-    # Step 3: Summary
-    print("\nStep 3/3: Ready!\n")
-
-    if not ENV_FILE.exists():
-        print(f"  Note: .env file created at {ENV_FILE}")
-
-    if use_elevenlabs:
-        print("  Provider: ElevenLabs (cloud)")
-        print("\n  Try it:")
-        print('    pidcast "https://youtube.com/watch?v=VIDEO_ID"')
-    else:
-        print("  Provider: whisper.cpp (local)")
-        print("\n  Try it:")
-        print('    pidcast "https://youtube.com/watch?v=VIDEO_ID"')
-
-    print()
-
-
-def resolve_output_dir(args: argparse.Namespace) -> Path:
-    """Resolve the transcript output directory.
-
-    Precedence (highest first):
-      1. ``--output-dir`` flag
-      2. ``config.yaml``'s ``output_dir`` (an explicit value the user set),
-         UNLESS it points at the legacy in-repo ``data/transcripts`` dir - older
-         configs pinned that absolute path before storage moved to the XDG data
-         dir, so we treat it as stale and fall through rather than sending new
-         transcripts back into the source tree.
-      3. the XDG ``TRANSCRIPTS_DIR`` default
-
-    Never falls back to the current working directory, so a run with no flag
-    lands artifacts in the canonical data dir instead of wherever you happen to
-    be standing.
+    Returns:
+        Parsed arguments namespace with ``command`` and ``func`` set.
     """
-    flag = getattr(args, "output_dir", None)
-    if flag:
-        return Path(flag)
+    import sys
 
-    from .config import PROJECT_ROOT
-    from .config_manager import ConfigManager
+    if argv is None:
+        argv = sys.argv[1:]
 
-    configured = ConfigManager.load_config().get("output_dir")
-    if configured and not _is_legacy_repo_path(Path(configured), PROJECT_ROOT):
-        return Path(configured)
-
-    return TRANSCRIPTS_DIR
+    parser = _build_parser()
+    return parser.parse_args(_inject_default_verb(argv))
 
 
-def _is_legacy_repo_path(path: Path, project_root: Path) -> bool:
-    """True if ``path`` is the old in-repo data/transcripts location (now stale)."""
-    legacy = project_root / "data" / "transcripts"
-    try:
-        return path.resolve() == legacy.resolve()
-    except OSError:
-        return False
+def _inject_default_verb(argv: list[str]) -> list[str]:
+    """Inject the implicit ``transcribe`` verb for the bare-input shortcut.
+
+    Rule: prepend ``transcribe`` only when the first token is a non-empty value
+    that is NOT a known verb and does NOT start with ``-``. So ``pidcast URL``
+    and ``pidcast file.mp3`` route to transcribe, while ``pidcast --help``,
+    ``pidcast lib list``, and ``pidcast info`` are left untouched. A file
+    literally named like a verb is shadowed (use ``transcribe ./info``).
+    """
+    if not argv:
+        return argv
+    first = argv[0]
+    if not first or first.startswith("-") or first in KNOWN_VERBS:
+        return argv
+    return ["transcribe", *argv]
 
 
-def print_paths() -> None:
-    """Print resolved data/config directories ('pidcast paths')."""
-    from .config import (
-        AUDIO_DIR,
-        CONFIG_DIR,
-        DATA_DIR,
-        LOGS_DIR,
-        RUNS_FILE,
-        STATE_DIR,
-        TRANSCRIPTS_DIR,
-        ensure_data_dirs,
-    )
+def build_transcribe_namespace(input_path: str) -> argparse.Namespace:
+    """Materialize a fully-defaulted ``transcribe`` Namespace for a given input.
 
-    ensure_data_dirs()
-    print("pidcast paths")
-    print(f"  data dir:     {DATA_DIR}")
-    print(f"  transcripts:  {TRANSCRIPTS_DIR}")
-    print(f"  audio:        {AUDIO_DIR}")
-    print(f"  logs:         {LOGS_DIR}")
-    print(f"  state:        {STATE_DIR}")
-    print(f"  run history:  {RUNS_FILE}")
-    print(f"  config dir:   {CONFIG_DIR}")
-    print("\n  Override the data dir with PIDCAST_DATA_DIR or XDG_DATA_HOME.")
+    Used by ``resume`` to rebuild the original run's args without mutating
+    ``sys.argv``. Every dest the transcribe workflow reads is present with its
+    default, ready to be overlaid with persisted checkpoint flags.
+    """
+    return parse_arguments(["transcribe", input_path])
+
+
+# ============================================================================
+# ENTRY POINT
+# ============================================================================
 
 
 def main() -> None:
     """Main entry point for pidcast CLI."""
-    import sys
+    from dotenv import load_dotenv
 
-    # Handle setup/doctor subcommands before arg parsing
-    if len(sys.argv) > 1:
-        if sys.argv[1] == "paths":
-            from dotenv import load_dotenv
-
-            load_dotenv()
-            print_paths()
-            return
-        if sys.argv[1] == "doctor":
-            from dotenv import load_dotenv
-
-            load_dotenv()
-            # doctor/setup dispatch before parse_arguments()/setup_logging(), so
-            # configure logging here or logger.* output is silently dropped.
-            setup_logging("--verbose" in sys.argv or "-v" in sys.argv)
-            cmd_doctor(prune_stats="--prune-stats" in sys.argv)
-            return
-        if sys.argv[1] == "setup":
-            from dotenv import load_dotenv
-
-            load_dotenv()
-            setup_logging("--verbose" in sys.argv or "-v" in sys.argv)
-            cmd_setup()
-            return
-        if sys.argv[1] == "resume":
-            from dotenv import load_dotenv
-
-            load_dotenv()
-            # These subcommands dispatch before parse_arguments()/setup_logging(),
-            # so configure logging here or every logger.* call is silently dropped.
-            verbose = "--verbose" in sys.argv or "-v" in sys.argv
-            setup_logging(verbose)
-            job_args = [a for a in sys.argv[2:] if not a.startswith("-")]
-            job_arg = job_args[0] if job_args else None
-            cmd_resume(job_arg)
-            return
+    # Env must load before parsing so env-backed defaults resolve.
+    load_dotenv()
 
     args = parse_arguments()
 
-    # Set up logging
-    setup_logging(getattr(args, "verbose", False))
-
-    # Handle --list-presets
-    if getattr(args, "list_presets", False):
-        from .config_manager import ConfigManager
-
-        presets = ConfigManager.list_presets()
-        if not presets:
-            print("No presets defined. Add presets to ~/.config/pidcast/config.yaml")
-            print("\nExample:")
-            print("  presets:")
-            print("    daily:")
-            print("      whisper_model: large-v3")
-            print("      language: uk")
-            print("      diarize: true")
-            print("      no_analyze: true")
-            print("      vad: true            # strip silence (anti-hallucination)")
-            print("      vad_threshold: 0.5")
-        else:
-            print("Available presets:\n")
-            for name, flags in presets.items():
-                flag_str = ", ".join(f"{k}={v}" for k, v in flags.items())
-                print(f"  {name}: {flag_str}")
-            print("\nUsage: pidcast <input> -p <preset>")
+    # No verb (and no bare input) -> show top-level help.
+    if not getattr(args, "command", None) or not hasattr(args, "func"):
+        _build_parser().print_help()
         return
 
-    # Apply preset if specified
+    setup_logging(getattr(args, "verbose", False))
+
+    # Apply preset if specified (transcribe/lib paths carry -p).
     if getattr(args, "preset", None):
         import sys
 
-        # Determine which args were explicitly set on CLI
         explicitly_set = set()
         for arg in vars(args):
             if any(
@@ -1687,8 +593,8 @@ def main() -> None:
             log_error(str(e))
             return
 
-    # Load chrome_profile from config if not explicitly set
-    if not getattr(args, "chrome_profile", None):
+    # Load chrome_profile from config if not explicitly set (download paths).
+    if hasattr(args, "chrome_profile") and not getattr(args, "chrome_profile", None):
         from .config_manager import ConfigManager
 
         config = ConfigManager.load_config()
@@ -1696,317 +602,7 @@ def main() -> None:
         if chrome_profile:
             args.chrome_profile = chrome_profile
 
-    # Handle discovery/list commands first (they exit immediately)
-    if getattr(args, "list_analyses", False):
-        from .utils import list_available_analyses
-
-        list_available_analyses()
-        return
-
-    if getattr(args, "list_models", False):
-        from .utils import list_available_models
-
-        list_available_models()
-        return
-
-    if getattr(args, "list_whisper_models", False):
-        from .transcription import list_whisper_models
-
-        models = list_whisper_models()
-        if not models:
-            print("No whisper models found. Set WHISPER_MODELS_DIR or WHISPER_MODEL env var.")
-        else:
-            print("Available Whisper models:\n")
-            for m in models:
-                print(f"  {m['name']:<25} {m['size']:>10}")
-            print(f"\nUsage: pidcast <input> --whisper_model {models[0]['name']}")
-        return
-
-    if getattr(args, "list_chrome_profiles", False):
-        from .cookies import list_chrome_profiles
-
-        profiles = list_chrome_profiles()
-        if not profiles:
-            print("No Chrome profiles found.")
-        else:
-            print("Available Chrome profiles:\n")
-            print(f"  {'Display Name':<25} {'Directory':<20} {'Config Value'}")
-            print(f"  {'-' * 25} {'-' * 20} {'-' * 30}")
-            for dir_name, meta in profiles.items():
-                print(f"  {meta['display_name']:<25} {dir_name:<20} {dir_name}")
-            print(f'\nUsage: pidcast <input> --chrome-profile "{list(profiles.keys())[0]}"')
-            print("   Or: Set 'chrome_profile' in ~/.config/pidcast/config.yaml")
-        return
-
-    # Route to library commands if specified
-    if getattr(args, "mode", None) == "lib":
-        lib_commands = {
-            "add": cmd_add,
-            "list": cmd_list,
-            "show": cmd_show,
-            "remove": cmd_remove,
-            "sync": cmd_sync,
-            "digest": cmd_digest,
-            "process": cmd_process,
-        }
-        handler = lib_commands.get(args.lib_command)
-        if handler:
-            handler(args)
-        return
-
-    # Validate that we have either input_source or analyze_existing for transcription workflow
-    if (
-        not args.input_source
-        and not args.analyze_existing
-        and not getattr(args, "diarize_existing", None)
-    ):
-        log_error("No input provided.")
-        logger.info('  Usage: pidcast "https://youtube.com/watch?v=VIDEO_ID"')
-        logger.info("         pidcast /path/to/audio.mp3")
-        logger.info("  First time? Run: pidcast setup")
-        logger.info("  Full help: pidcast --help")
-        return
-
-    # Resolve analysis type with fuzzy matching
-    if args.analysis_type and args.analysis_type != "executive_summary":
-        from .utils import resolve_analysis_type
-
-        try:
-            resolved_type = resolve_analysis_type(args.analysis_type, args.prompts_file)
-            if resolved_type != args.analysis_type and args.verbose:
-                logger.info(f"Matched '{args.analysis_type}' → '{resolved_type}'")
-            args.analysis_type = resolved_type
-        except ValueError as e:
-            log_error(str(e))
-            return
-
-    # Resolve model name with fuzzy matching
-    if args.groq_model:
-        from .utils import resolve_model_name
-
-        try:
-            resolved_model = resolve_model_name(args.groq_model)
-            if resolved_model != args.groq_model and args.verbose:
-                logger.info(f"Matched '{args.groq_model}' → '{resolved_model}'")
-            args.groq_model = resolved_model
-        except ValueError as e:
-            log_error(str(e))
-            return
-
-    # Resolve whisper model name to path (only needed for whisper provider)
-    transcription_provider = getattr(args, "transcription_provider", "whisper")
-    if args.whisper_model and not args.analyze_existing and transcription_provider == "whisper":
-        from .transcription import resolve_whisper_model
-
-        try:
-            resolved = resolve_whisper_model(args.whisper_model)
-            if resolved != args.whisper_model and args.verbose:
-                logger.info(f"Whisper model: '{args.whisper_model}' -> {resolved}")
-            args.whisper_model = resolved
-        except Exception as e:
-            log_error(str(e))
-            return
-
-    # Set defaults for paths
-    output_dir = resolve_output_dir(args)
-    stats_file = Path(args.stats_file) if args.stats_file else RUNS_FILE
-
-    # Determine where analysis files should go
-    analysis_output_dir = Path(OBSIDIAN_PATH) if args.save_to_obsidian else output_dir
-
-    if args.save_to_obsidian and args.verbose:
-        logger.info(f"Analysis will be saved to Obsidian vault: {analysis_output_dir}")
-        logger.info(f"Transcripts will be saved to: {output_dir}")
-
-    # Initialize tracking variables
-    run_uid = str(uuid.uuid4())
-    run_timestamp = datetime.datetime.now().isoformat()
-    start_time = time.time()
-
-    # Validate test-segment options
-    test_segment = getattr(args, "test_segment", None)
-    start_at = getattr(args, "start_at", None)
-
-    if test_segment is not None:
-        if test_segment <= 0:
-            log_error("--test-segment duration must be positive")
-            return
-        if test_segment > 30:
-            log_error("--test-segment maximum is 30 minutes")
-            return
-        if args.analyze_existing:
-            log_error("--test-segment cannot be used with --analyze_existing")
-            return
-
-    if start_at is not None:
-        if test_segment is None:
-            log_error("--start-at requires --test-segment")
-            return
-        if start_at < 0:
-            log_error("--start-at must be non-negative")
-            return
-
-    # Validate --audio flag
-    if getattr(args, "audio", None) and not getattr(args, "diarize_existing", None):
-        log_error("--audio requires --diarize-existing")
-        return
-
-    # Handle diarize-existing mode
-    diarize_existing = getattr(args, "diarize_existing", None)
-    if diarize_existing:
-        from .workflow import run_diarize_existing_mode
-
-        run_diarize_existing_mode(
-            diarize_existing,
-            audio_override=getattr(args, "audio", None),
-            verbose=args.verbose,
-        )
-        return
-
-    # Handle analyze-existing mode
-    if args.analyze_existing:
-        if args.no_analyze:
-            log_error(
-                "--no-analyze cannot be used with --analyze_existing. "
-                "The purpose of --analyze_existing is to analyze a transcript."
-            )
-            return
-
-        run_analyze_existing_mode(
-            args.analyze_existing,
-            args,
-            output_dir,
-            analysis_output_dir,
-            stats_file,
-            run_uid,
-            run_timestamp,
-            start_time,
-        )
-        return
-
-    if args.verbose:
-        log_section("Transcription Tool")
-        logger.info(f"Input: {args.input_source}")
-        logger.info(f"Run ID: {run_uid}")
-        logger.info(f"Timestamp: {run_timestamp}")
-
-    # Check for duplicate transcription (unless --force or --test-segment is used)
-    if not args.force and test_segment is None:
-        prev_transcription = find_existing_transcription(stats_file, args.input_source, output_dir)
-
-        if prev_transcription:
-            # Handle non-interactive mode
-            if not is_interactive():
-                log_error(
-                    f"Duplicate detected: '{prev_transcription.video_title}' "
-                    f"was already transcribed on {prev_transcription.formatted_date}. "
-                    "Use --force to proceed anyway."
-                )
-                return
-
-            # Interactive mode: prompt user for action
-            action = prompt_duplicate_detected(prev_transcription, args.verbose)
-
-            if action == DuplicateAction.CANCEL:
-                logger.info("Operation cancelled.")
-                return
-
-            elif action == DuplicateAction.ANALYZE_EXISTING:
-                run_analyze_existing_mode(
-                    prev_transcription.transcript_path,
-                    args,
-                    output_dir,
-                    analysis_output_dir,
-                    stats_file,
-                    run_uid,
-                    run_timestamp,
-                    start_time,
-                )
-                return
-
-            elif action == DuplicateAction.RE_TRANSCRIBE:
-                logger.info("Re-transcribing video...")
-
-            elif action == DuplicateAction.FORCE_CONTINUE:
-                logger.info("Continuing with transcription...")
-
-    # Run the main transcription workflow under a pause-aware SIGINT handler.
-    _run_with_pause_handler(
-        lambda: process_input_source(
-            args.input_source,
-            args,
-            output_dir,
-            analysis_output_dir,
-            stats_file,
-            run_uid,
-            run_timestamp,
-            start_time,
-        )
-    )
-
-
-def _run_with_pause_handler(run_fn) -> None:
-    """Run ``run_fn`` with Ctrl-C wired to a clean transcription pause.
-
-    First Ctrl-C requests a pause (the whisper stream loop stops at the next
-    segment boundary and the job is checkpointed). A second Ctrl-C restores the
-    default handler and hard-quits.
-    """
-    import signal
-
-    from .workflow import request_pause
-
-    state = {"count": 0}
-    original = signal.getsignal(signal.SIGINT)
-
-    def _handler(signum, frame):
-        state["count"] += 1
-        if state["count"] == 1:
-            logger.info(
-                "\nPausing transcription at the next segment boundary... (Ctrl-C again to force quit)"
-            )
-            request_pause()
-        else:
-            signal.signal(signal.SIGINT, original)
-            raise KeyboardInterrupt
-
-    signal.signal(signal.SIGINT, _handler)
-    try:
-        run_fn()
-    finally:
-        signal.signal(signal.SIGINT, original)
-
-
-def cmd_resume(job_arg: str | None) -> None:
-    """Resume a paused/interrupted transcription job (``pidcast resume [job-id]``)."""
-    from .checkpoint import DONE, JobManifest, find_resumable_jobs
-    from .resume import resume_job
-
-    jobs = find_resumable_jobs()
-    if not jobs:
-        logger.info("No resumable jobs found.")
-        return
-
-    manifest: JobManifest | None = None
-    if job_arg:
-        manifest = next((j for j in jobs if j.job_id.startswith(job_arg)), None)
-        if manifest is None:
-            logger.error(f"No resumable job matching '{job_arg}'.")
-            return
-    elif len(jobs) == 1:
-        manifest = jobs[0]
-    else:
-        logger.info("Multiple resumable jobs - pass a job id to pick one:\n")
-        for j in jobs:
-            phase = "diarization" if j.transcription.status == DONE else "transcription"
-            title = (j.video_info or {}).get("title", j.input_source)
-            logger.info(
-                f"  {j.job_id}  [{phase}]  {title}  "
-                f"({j.transcription.segment_count} segments, updated {j.updated_at})"
-            )
-        return
-
-    resume_job(manifest)
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/src/pidcast/commands/__init__.py
+++ b/src/pidcast/commands/__init__.py
@@ -1,0 +1,5 @@
+"""Command handlers for the pidcast CLI verbs.
+
+Each module owns the body of one verb (or verb group). ``cli.py`` wires these to
+subparsers via ``set_defaults(func=...)`` and stays a thin parser/dispatch layer.
+"""

--- a/src/pidcast/commands/analyze.py
+++ b/src/pidcast/commands/analyze.py
@@ -1,0 +1,58 @@
+"""Handler for ``pidcast analyze <transcript>`` (re-analyze an existing file)."""
+
+import argparse
+import datetime
+import logging
+import time
+import uuid
+from pathlib import Path
+
+from ..config import OBSIDIAN_PATH, RUNS_FILE, resolve_output_dir
+from ..utils import log_error
+from ..workflow import run_analyze_existing_mode
+
+logger = logging.getLogger(__name__)
+
+
+def cmd_analyze(args: argparse.Namespace) -> None:
+    """Analyze an existing transcript without re-transcribing."""
+    # Resolve analysis type with fuzzy matching
+    if args.analysis_type and args.analysis_type != "executive_summary":
+        from ..utils import resolve_analysis_type
+
+        try:
+            resolved_type = resolve_analysis_type(args.analysis_type, args.prompts_file)
+            if resolved_type != args.analysis_type and args.verbose:
+                logger.info(f"Matched '{args.analysis_type}' → '{resolved_type}'")
+            args.analysis_type = resolved_type
+        except ValueError as e:
+            log_error(str(e))
+            return
+
+    # Resolve model name with fuzzy matching
+    if args.groq_model:
+        from ..utils import resolve_model_name
+
+        try:
+            resolved_model = resolve_model_name(args.groq_model)
+            if resolved_model != args.groq_model and args.verbose:
+                logger.info(f"Matched '{args.groq_model}' → '{resolved_model}'")
+            args.groq_model = resolved_model
+        except ValueError as e:
+            log_error(str(e))
+            return
+
+    output_dir = resolve_output_dir(args)
+    stats_file = Path(args.stats_file) if args.stats_file else RUNS_FILE
+    analysis_output_dir = Path(OBSIDIAN_PATH) if args.save_to_obsidian else output_dir
+
+    run_analyze_existing_mode(
+        args.transcript,
+        args,
+        output_dir,
+        analysis_output_dir,
+        stats_file,
+        str(uuid.uuid4()),
+        datetime.datetime.now().isoformat(),
+        time.time(),
+    )

--- a/src/pidcast/commands/diarize.py
+++ b/src/pidcast/commands/diarize.py
@@ -1,0 +1,17 @@
+"""Handler for ``pidcast diarize <transcript>`` (retry diarization only)."""
+
+import argparse
+import logging
+
+from ..workflow import run_diarize_existing_mode
+
+logger = logging.getLogger(__name__)
+
+
+def cmd_diarize(args: argparse.Namespace) -> None:
+    """Run speaker diarization on an existing transcript (no re-transcription)."""
+    run_diarize_existing_mode(
+        args.transcript,
+        audio_override=getattr(args, "audio", None),
+        verbose=args.verbose,
+    )

--- a/src/pidcast/commands/info.py
+++ b/src/pidcast/commands/info.py
@@ -1,0 +1,31 @@
+"""Handler for ``pidcast info`` — resolved data/config paths (folds in `paths`)."""
+
+import argparse
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def cmd_info(args: argparse.Namespace) -> None:
+    """Print resolved data/config directories."""
+    from ..config import (
+        AUDIO_DIR,
+        CONFIG_DIR,
+        DATA_DIR,
+        LOGS_DIR,
+        RUNS_FILE,
+        STATE_DIR,
+        TRANSCRIPTS_DIR,
+        ensure_data_dirs,
+    )
+
+    ensure_data_dirs()
+    print("pidcast info")
+    print(f"  data dir:     {DATA_DIR}")
+    print(f"  transcripts:  {TRANSCRIPTS_DIR}")
+    print(f"  audio:        {AUDIO_DIR}")
+    print(f"  logs:         {LOGS_DIR}")
+    print(f"  state:        {STATE_DIR}")
+    print(f"  run history:  {RUNS_FILE}")
+    print(f"  config dir:   {CONFIG_DIR}")
+    print("\n  Override the data dir with PIDCAST_DATA_DIR or XDG_DATA_HOME.")

--- a/src/pidcast/commands/lib.py
+++ b/src/pidcast/commands/lib.py
@@ -1,0 +1,616 @@
+"""Handlers for the ``pidcast lib`` subcommands.
+
+Bodies lifted verbatim from the old monolithic ``cli.py`` (cmd_* -> handle_*),
+with ``resolve_output_dir`` re-homed to ``config``. Kept out of ``library.py``
+(the data layer) so the show store stays free of workflow coupling.
+"""
+
+import argparse
+import datetime
+import logging
+import os
+import time
+import traceback
+import uuid
+from pathlib import Path
+
+from ..config import RUNS_FILE, resolve_output_dir
+from ..exceptions import DuplicateShowError, FeedFetchError, FeedParseError, ShowNotFoundError
+from ..utils import log_error
+from ..workflow import process_input_source
+
+logger = logging.getLogger(__name__)
+
+
+def handle_process(args: argparse.Namespace) -> None:
+    """Handle 'pidcast lib process' command."""
+    from ..config import OBSIDIAN_PATH, VideoInfo
+    from ..library import LibraryManager, Show
+
+    library = LibraryManager()
+
+    # Find show
+    show_query = args.show_query
+    show: Show | None = None
+
+    # Try as ID
+    try:
+        show_id = int(show_query)
+        show = library.get_show(show_id)
+    except ValueError:
+        pass
+
+    # Try as name (case insensitive partial match)
+    if not show:
+        matches = [s for s in library.list_shows() if show_query.lower() in s.title.lower()]
+        if len(matches) == 1:
+            show = matches[0]
+        elif len(matches) > 1:
+            print(f"Ambiguous show name '{show_query}'. Matches:")
+            for s in matches:
+                print(f"  {s.id}: {s.title}")
+            return
+
+    if not show:
+        log_error(f"Show '{show_query}' not found.")
+        return
+
+    # Fetch episodes
+    episodes = library.get_episodes(show.id, limit=50 if args.match else 20, verbose=args.verbose)
+
+    selected_episode = None
+
+    if args.latest:
+        selected_episode = episodes[0] if episodes else None
+    elif args.match:
+        # fuzzy match title
+        query = args.match.lower()
+        for ep in episodes:
+            if query in ep.title.lower():
+                selected_episode = ep
+                break
+        if not selected_episode:
+            log_error(f"No episode found matching '{args.match}'")
+            return
+    else:
+        # Interactive selection
+        try:
+            from rich.console import Console
+            from rich.prompt import Prompt
+            from rich.table import Table
+
+            console = Console()
+
+            table = Table(show_header=True)
+            table.add_column("#", style="cyan", width=4)
+            table.add_column("Date", style="yellow", width=12)
+            table.add_column("Title", style="white")
+
+            # Show top 10
+            display_episodes = episodes[:10]
+            for i, ep in enumerate(display_episodes, 1):
+                table.add_row(str(i), ep.pub_date.strftime("%Y-%m-%d"), ep.title)
+
+            console.print(table)
+
+            # Ask for selection
+            choices = [str(i) for i in range(1, len(display_episodes) + 1)]
+            choice = Prompt.ask("Select episode", choices=choices)
+            selected_episode = display_episodes[int(choice) - 1]
+        except ImportError:
+            # Fallback
+            print("Rich not installed, and no selection flags used. Defaulting to latest.")
+            selected_episode = episodes[0] if episodes else None
+
+    if not selected_episode:
+        log_error("No episodes found.")
+        return
+
+    logger.info(f"\nProcessing: {selected_episode.title} ({show.title})")
+
+    # Construct override
+    video_info = VideoInfo(
+        title=selected_episode.title,
+        webpage_url=selected_episode.audio_url,
+        channel=show.title,
+        upload_date=selected_episode.pub_date.strftime("%Y%m%d"),
+        description=selected_episode.description,
+        duration=selected_episode.duration or 0,
+    )
+
+    # Resolve whisper model
+    if args.whisper_model:
+        from ..transcription import resolve_whisper_model
+
+        try:
+            args.whisper_model = resolve_whisper_model(args.whisper_model)
+        except Exception as e:
+            log_error(str(e))
+            return
+
+    # Run workflow
+    output_dir = resolve_output_dir(args)
+    stats_file = Path(args.stats_file) if args.stats_file else RUNS_FILE
+    analysis_output_dir = Path(OBSIDIAN_PATH) if args.save_to_obsidian else output_dir
+
+    process_input_source(
+        selected_episode.audio_url,
+        args,
+        output_dir,
+        analysis_output_dir,
+        stats_file,
+        str(uuid.uuid4()),
+        datetime.datetime.now().isoformat(),
+        time.time(),
+        video_info_override=video_info,
+    )
+
+
+def handle_add(args: argparse.Namespace) -> None:
+    """Handle 'pidcast lib add' command."""
+    from ..config_manager import ConfigManager
+    from ..library import LibraryManager
+    from ..rss import RSSParser
+
+    try:
+        from rich.console import Console
+        from rich.prompt import Confirm
+        from rich.table import Table
+
+        has_rich = True
+    except ImportError:
+        has_rich = False
+
+    # Initialize config and library
+    ConfigManager.init_default_config()
+    library = LibraryManager()
+
+    # Resolve feed URL from name if user didn't pass a URL
+    feed_url = args.feed_url
+    if not feed_url.startswith(("http://", "https://", "feed://")):
+        from ..discovery import discover_podcast, prompt_user_selection
+
+        query = feed_url
+        if has_rich:
+            Console().print(f"\nSearching for podcasts matching [bold]{query!r}[/bold]...")
+        else:
+            print(f"\nSearching for podcasts matching {query!r}...")
+
+        results = discover_podcast(query)
+        if not results:
+            log_error(f"No podcasts found for {query!r}. Try using the RSS feed URL directly.")
+            return
+
+        chosen = prompt_user_selection(results)
+        if chosen is None:
+            logger.info("Cancelled.")
+            return
+
+        feed_url = chosen["feed_url"]
+        args.feed_url = feed_url
+
+    try:
+        # Preview mode: show episodes before adding
+        if args.preview:
+            if args.verbose:
+                logger.info(f"Fetching feed preview: {args.feed_url}")
+
+            show_meta, episodes = RSSParser.parse_feed(args.feed_url, verbose=args.verbose)
+
+            if has_rich:
+                console = Console()
+                console.print(f"\n[bold cyan]Show:[/bold cyan] {show_meta['title']}")
+                console.print(f"[bold cyan]Author:[/bold cyan] {show_meta['author']}")
+                console.print("\n[bold]Recent Episodes:[/bold]")
+
+                table = Table(show_header=True)
+                table.add_column("#", style="cyan", width=4)
+                table.add_column("Date", style="yellow", width=12)
+                table.add_column("Title", style="white")
+
+                for i, episode in enumerate(episodes[:5], 1):
+                    date_str = episode.pub_date.strftime("%Y-%m-%d")
+                    table.add_row(str(i), date_str, episode.title)
+
+                console.print(table)
+                console.print(f"\nTotal episodes: {len(episodes)}")
+
+                if not Confirm.ask("\nAdd this show to library?", default=True):
+                    logger.info("Cancelled.")
+                    return
+            else:
+                print(f"\nShow: {show_meta['title']}")
+                print(f"Author: {show_meta['author']}")
+                print("\nRecent Episodes:")
+                for i, episode in enumerate(episodes[:5], 1):
+                    print(f"  {i}. {episode}")
+                print(f"\nTotal episodes: {len(episodes)}")
+
+                confirm = input("\nAdd this show to library? [Y/n]: ").strip().lower()
+                if confirm and confirm not in ["y", "yes"]:
+                    logger.info("Cancelled.")
+                    return
+
+        # Add show to library
+        show = library.add_show(args.feed_url, verbose=args.verbose)
+
+        if has_rich:
+            console = Console()
+            console.print(f"\n[green]✓[/green] Added: [bold]{show.title}[/bold] (ID: {show.id})")
+        else:
+            print(f"\n✓ Added: {show.title} (ID: {show.id})")
+
+    except DuplicateShowError as e:
+        log_error(str(e))
+    except (FeedFetchError, FeedParseError) as e:
+        log_error(f"Failed to add show: {e}")
+        if args.verbose:
+            traceback.print_exc()
+    except Exception as e:
+        log_error(f"An unexpected error occurred: {e}")
+        if args.verbose:
+            traceback.print_exc()
+
+
+def handle_list(args: argparse.Namespace) -> None:
+    """Handle 'pidcast lib list' command."""
+    from ..library import LibraryManager
+
+    try:
+        from rich.console import Console
+        from rich.table import Table
+
+        has_rich = True
+    except ImportError:
+        has_rich = False
+
+    # Initialize library
+    library = LibraryManager()
+    shows = library.list_shows()
+
+    if not shows:
+        logger.info("No shows in library. Use 'pidcast lib add <feed-url>' to add shows.")
+        return
+
+    if has_rich:
+        console = Console()
+        table = Table(show_header=True, title=f"Podcast Library ({len(shows)} shows)")
+        table.add_column("ID", style="cyan", width=4)
+        table.add_column("Title", style="white")
+        table.add_column("Author", style="yellow")
+        table.add_column("Added", style="dim", width=12)
+
+        for show in shows:
+            added_str = show.added_at.strftime("%Y-%m-%d")
+            table.add_row(str(show.id), show.title, show.author or "Unknown", added_str)
+
+        console.print(table)
+    else:
+        print(f"\nPodcast Library ({len(shows)} shows):")
+        print("-" * 80)
+        for show in shows:
+            added_str = show.added_at.strftime("%Y-%m-%d")
+            print(f"ID: {show.id}")
+            print(f"  Title: {show.title}")
+            print(f"  Author: {show.author or 'Unknown'}")
+            print(f"  Added: {added_str}")
+            print()
+
+
+def handle_show(args: argparse.Namespace) -> None:
+    """Handle 'pidcast lib show' command."""
+    from ..library import LibraryManager
+
+    try:
+        from rich.console import Console
+        from rich.panel import Panel
+        from rich.table import Table
+
+        has_rich = True
+    except ImportError:
+        has_rich = False
+
+    # Initialize library
+    library = LibraryManager()
+
+    try:
+        show = library.get_show(args.show_id)
+        if not show:
+            log_error(
+                f"Show ID {args.show_id} not found. Run 'pidcast lib list' to see available shows."
+            )
+            return
+
+        # Fetch episodes
+        episodes = library.get_episodes(args.show_id, limit=args.episodes, verbose=args.verbose)
+
+        if has_rich:
+            console = Console()
+
+            # Show metadata
+            info_table = Table(show_header=False, box=None, padding=(0, 2))
+            info_table.add_column(style="cyan bold", width=15)
+            info_table.add_column(style="white")
+
+            info_table.add_row("ID", str(show.id))
+            info_table.add_row("Title", show.title)
+            info_table.add_row("Author", show.author or "Unknown")
+            info_table.add_row("Feed URL", show.feed_url)
+            info_table.add_row("Added", show.added_at.strftime("%Y-%m-%d %H:%M"))
+            if show.last_checked:
+                info_table.add_row("Last Checked", show.last_checked.strftime("%Y-%m-%d %H:%M"))
+
+            console.print(
+                Panel(info_table, title=f"[bold]{show.title}[/bold]", border_style="cyan")
+            )
+
+            # Episodes
+            console.print(f"\n[bold]Recent Episodes (showing {len(episodes)}):[/bold]")
+            ep_table = Table(show_header=True)
+            ep_table.add_column("#", style="cyan", width=4)
+            ep_table.add_column("Date", style="yellow", width=12)
+            ep_table.add_column("Duration", style="dim", width=10)
+            ep_table.add_column("Title", style="white")
+
+            for i, episode in enumerate(episodes, 1):
+                date_str = episode.pub_date.strftime("%Y-%m-%d")
+                duration_str = f"{episode.duration // 60}m" if episode.duration else "Unknown"
+                ep_table.add_row(str(i), date_str, duration_str, episode.title)
+
+            console.print(ep_table)
+        else:
+            print(f"\n{'=' * 80}")
+            print(f"Show Details (ID: {show.id})")
+            print(f"{'=' * 80}")
+            print(f"Title: {show.title}")
+            print(f"Author: {show.author or 'Unknown'}")
+            print(f"Feed URL: {show.feed_url}")
+            print(f"Added: {show.added_at.strftime('%Y-%m-%d %H:%M')}")
+            if show.last_checked:
+                print(f"Last Checked: {show.last_checked.strftime('%Y-%m-%d %H:%M')}")
+
+            print(f"\nRecent Episodes (showing {len(episodes)}):")
+            print("-" * 80)
+            for i, episode in enumerate(episodes, 1):
+                print(f"{i}. {episode}")
+            print()
+
+    except ShowNotFoundError as e:
+        log_error(str(e))
+    except (FeedFetchError, FeedParseError) as e:
+        log_error(f"Failed to fetch episodes: {e}")
+        if args.verbose:
+            traceback.print_exc()
+    except Exception as e:
+        log_error(f"An unexpected error occurred: {e}")
+        if args.verbose:
+            traceback.print_exc()
+
+
+def handle_remove(args: argparse.Namespace) -> None:
+    """Handle 'pidcast lib remove' command."""
+    from ..library import LibraryManager
+
+    try:
+        from rich.console import Console
+
+        has_rich = True
+    except ImportError:
+        has_rich = False
+
+    # Initialize library
+    library = LibraryManager()
+
+    # Get show details before removing
+    show = library.get_show(args.show_id)
+    if not show:
+        log_error(
+            f"Show ID {args.show_id} not found. Run 'pidcast lib list' to see available shows."
+        )
+        return
+
+    # Remove show
+    if library.remove_show(args.show_id):
+        if has_rich:
+            console = Console()
+            console.print(f"\n[green]✓[/green] Removed: [bold]{show.title}[/bold] (ID: {show.id})")
+        else:
+            print(f"\n✓ Removed: {show.title} (ID: {show.id})")
+    else:
+        log_error(f"Failed to remove show ID {args.show_id}")
+
+
+def handle_digest(args: argparse.Namespace) -> None:
+    """Handle 'pidcast lib digest' command."""
+    from datetime import datetime, timedelta
+
+    from ..config import DEFAULT_PROMPTS_FILE, HISTORY_FILE, get_digest_output_path
+    from ..digest import DigestFormatter, DigestGenerator
+    from ..history import ProcessingHistory
+    from ..library import LibraryManager
+    from ..summarization import Summarizer
+
+    # Get Groq API key
+    groq_api_key = args.groq_api_key or os.environ.get("GROQ_API_KEY")
+    if not groq_api_key:
+        log_error(
+            "Groq API key not found. Set GROQ_API_KEY environment variable or use --groq_api_key"
+        )
+        return
+
+    # Initialize components
+    library = LibraryManager()
+    history = ProcessingHistory(HISTORY_FILE)
+    prompts_file = Path(args.prompts_file) if args.prompts_file else DEFAULT_PROMPTS_FILE
+    summarizer = Summarizer(prompts_file, groq_api_key)
+
+    generator = DigestGenerator(library, history, summarizer)
+
+    # Parse date filters
+    date_filter = None
+    date_range = None
+
+    if args.date:
+        try:
+            date_filter = datetime.strptime(args.date, "%Y-%m-%d")
+        except ValueError:
+            log_error(f"Invalid date format: {args.date}. Use YYYY-MM-DD format.")
+            return
+    elif args.range:
+        # Parse range like "7d", "30d"
+        try:
+            if args.range.endswith("d"):
+                days = int(args.range[:-1])
+                date_range = timedelta(days=days)
+            else:
+                log_error(f"Invalid range format: {args.range}. Use format like '7d' or '30d'.")
+                return
+        except ValueError:
+            log_error(f"Invalid range format: {args.range}. Use format like '7d' or '30d'.")
+            return
+    else:
+        # Default: today's episodes
+        date_filter = datetime.now()
+
+    # Generate digest
+    try:
+        logger.info("Generating digest...")
+        digest = generator.generate_digest(date_filter, date_range)
+
+        if not digest.episodes:
+            logger.info("No episodes found for specified date range.")
+            return
+
+        # Display in terminal
+        DigestFormatter.format_terminal(digest)
+
+        # Save to file (digest path comes from DIGESTS_DIR via get_digest_output_path)
+        output_dir = resolve_output_dir(args)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = get_digest_output_path(date_filter or datetime.now())
+
+        markdown = DigestFormatter.format_markdown(digest)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(markdown)
+
+        logger.info(f"\nDigest saved to: {output_path}")
+
+    except Exception as e:
+        log_error(f"Failed to generate digest: {e}")
+        if args.verbose:
+            traceback.print_exc()
+
+
+def handle_sync(args: argparse.Namespace) -> None:
+    """Handle 'pidcast lib sync' command."""
+    from ..config import DEFAULT_BACKFILL_LIMIT, HISTORY_FILE, WHISPER_MODEL
+    from ..history import ProcessingHistory
+    from ..library import LibraryManager
+    from ..sync import SyncEngine
+
+    # Initialize library and history
+    library = LibraryManager()
+    history = ProcessingHistory(HISTORY_FILE)
+
+    # Get output directory
+    output_dir = resolve_output_dir(args)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Get Whisper model
+    whisper_model = args.whisper_model or WHISPER_MODEL
+    if not whisper_model:
+        log_error(
+            "Whisper model not specified. Set WHISPER_MODEL environment variable "
+            "or use --whisper_model flag"
+        )
+        return
+
+    # Resolve model name to path
+    from ..transcription import resolve_whisper_model
+
+    try:
+        whisper_model = resolve_whisper_model(whisper_model)
+    except Exception as e:
+        log_error(str(e))
+        return
+
+    # Get Groq API key (optional)
+    groq_api_key = args.groq_api_key or os.environ.get("GROQ_API_KEY")
+
+    # Build config
+    config = {
+        "backfill_limit": DEFAULT_BACKFILL_LIMIT,
+    }
+
+    # Create sync engine
+    engine = SyncEngine(
+        library=library,
+        history=history,
+        config=config,
+        output_dir=output_dir,
+        whisper_model=whisper_model,
+        groq_api_key=groq_api_key,
+        analysis_type=args.analysis_type,
+        prompts_file=Path(args.prompts_file) if args.prompts_file else None,
+        verbose=args.verbose,
+    )
+
+    # Run sync
+    try:
+        stats = engine.sync(
+            show_id=args.show,
+            dry_run=args.dry_run,
+            force=args.force,
+            backfill=args.backfill,
+        )
+
+        # Print summary
+        logger.info(f"\n{'=' * 60}")
+        logger.info("Sync Complete!")
+        logger.info(f"{'=' * 60}")
+        logger.info(f"Processed: {stats['processed']} episodes")
+        logger.info(f"Succeeded: {stats['succeeded']}")
+        logger.info(f"Failed: {stats['failed']}")
+        if stats["skipped"] > 0:
+            logger.info(f"Skipped: {stats['skipped']} (already processed)")
+        logger.info(f"{'=' * 60}\n")
+
+        # Generate digest unless --no-digest flag is set
+        if not args.no_digest and stats["succeeded"] > 0 and groq_api_key:
+            from datetime import datetime
+
+            from ..config import DEFAULT_PROMPTS_FILE, get_digest_output_path
+            from ..digest import DigestFormatter, DigestGenerator
+            from ..summarization import Summarizer
+
+            try:
+                logger.info("Generating digest...")
+                prompts_file = (
+                    Path(args.prompts_file) if args.prompts_file else DEFAULT_PROMPTS_FILE
+                )
+                summarizer = Summarizer(prompts_file, groq_api_key)
+                digest_generator = DigestGenerator(library, history, summarizer)
+
+                # Generate digest for today's processed episodes
+                digest = digest_generator.generate_digest(date_filter=datetime.now())
+
+                if digest.episodes:
+                    DigestFormatter.format_terminal(digest)
+
+                    # Save digest
+                    output_path = get_digest_output_path(datetime.now())
+                    markdown = DigestFormatter.format_markdown(digest)
+                    with open(output_path, "w", encoding="utf-8") as f:
+                        f.write(markdown)
+
+                    logger.info(f"\n✓ Digest saved to: {output_path}")
+
+            except Exception as e:
+                logger.warning(f"Failed to generate digest: {e}")
+                if args.verbose:
+                    traceback.print_exc()
+
+    except Exception as e:
+        log_error(f"Sync failed: {e}")
+        if args.verbose:
+            traceback.print_exc()

--- a/src/pidcast/commands/listing.py
+++ b/src/pidcast/commands/listing.py
@@ -1,0 +1,91 @@
+"""Handler for ``pidcast list <thing>`` — consolidated discovery commands.
+
+Replaces the old cryptic ``-L/-M/-W/-P`` flags and ``--list-chrome-profiles``
+with one verb whose ``thing`` positional selects what to list.
+"""
+
+import argparse
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def cmd_list(args: argparse.Namespace) -> None:
+    """Dispatch ``pidcast list <thing>`` to the matching discovery routine."""
+    thing = args.thing
+    dispatch = {
+        "analyses": _list_analyses,
+        "models": _list_models,
+        "whisper-models": _list_whisper_models,
+        "presets": _list_presets,
+        "profiles": _list_profiles,
+    }
+    handler = dispatch.get(thing)
+    if handler is None:  # argparse choices guard this, but be defensive
+        print(f"Unknown list target: {thing}")
+        return
+    handler()
+
+
+def _list_analyses() -> None:
+    from ..utils import list_available_analyses
+
+    list_available_analyses()
+
+
+def _list_models() -> None:
+    from ..utils import list_available_models
+
+    list_available_models()
+
+
+def _list_whisper_models() -> None:
+    from ..transcription import list_whisper_models
+
+    models = list_whisper_models()
+    if not models:
+        print("No whisper models found. Set WHISPER_MODELS_DIR or WHISPER_MODEL env var.")
+    else:
+        print("Available Whisper models:\n")
+        for m in models:
+            print(f"  {m['name']:<25} {m['size']:>10}")
+        print(f"\nUsage: pidcast transcribe <input> --whisper-model {models[0]['name']}")
+
+
+def _list_presets() -> None:
+    from ..config_manager import ConfigManager
+
+    presets = ConfigManager.list_presets()
+    if not presets:
+        print("No presets defined. Add presets to ~/.config/pidcast/config.yaml")
+        print("\nExample:")
+        print("  presets:")
+        print("    daily:")
+        print("      whisper_model: large-v3")
+        print("      language: uk")
+        print("      diarize: true")
+        print("      no_analyze: true")
+        print("      vad: true            # strip silence (anti-hallucination)")
+        print("      vad_threshold: 0.5")
+    else:
+        print("Available presets:\n")
+        for name, flags in presets.items():
+            flag_str = ", ".join(f"{k}={v}" for k, v in flags.items())
+            print(f"  {name}: {flag_str}")
+        print("\nUsage: pidcast transcribe <input> -p <preset>")
+
+
+def _list_profiles() -> None:
+    from ..cookies import list_chrome_profiles
+
+    profiles = list_chrome_profiles()
+    if not profiles:
+        print("No Chrome profiles found.")
+    else:
+        print("Available Chrome profiles:\n")
+        print(f"  {'Display Name':<25} {'Directory':<20} {'Config Value'}")
+        print(f"  {'-' * 25} {'-' * 20} {'-' * 30}")
+        for dir_name, meta in profiles.items():
+            print(f"  {meta['display_name']:<25} {dir_name:<20} {dir_name}")
+        print(f'\nUsage: pidcast transcribe <input> --chrome-profile "{list(profiles.keys())[0]}"')
+        print("   Or: Set 'chrome_profile' in ~/.config/pidcast/config.yaml")

--- a/src/pidcast/commands/transcribe.py
+++ b/src/pidcast/commands/transcribe.py
@@ -160,19 +160,22 @@ def cmd_transcribe(args: argparse.Namespace) -> None:
             run_uid,
             run_timestamp,
             start_time,
-        )
+        ),
+        verbose=args.verbose,
     )
 
 
-def _run_with_pause_handler(run_fn) -> None:
-    """Run ``run_fn`` with Ctrl-C wired to a clean transcription pause.
+def _run_with_pause_handler(run_fn, verbose: bool = False) -> None:
+    """Run ``run_fn`` under the run's single Live display and a pause-aware SIGINT.
 
-    First Ctrl-C requests a pause (the whisper stream loop stops at the next
-    segment boundary and the job is checkpointed). A second Ctrl-C restores the
-    default handler and hard-quits.
+    The ``RunReporter`` owns one progress display for the whole run so output is
+    stable (no pushed-down bar). First Ctrl-C requests a clean pause (the whisper
+    stream loop stops at the next segment boundary and the job is checkpointed);
+    a second Ctrl-C restores the default handler and hard-quits.
     """
     import signal
 
+    from ..ui import RunReporter
     from ..workflow import request_pause
 
     state = {"count": 0}
@@ -192,6 +195,7 @@ def _run_with_pause_handler(run_fn) -> None:
 
     signal.signal(signal.SIGINT, _handler)
     try:
-        run_fn()
+        with RunReporter(verbose=verbose):
+            run_fn()
     finally:
         signal.signal(signal.SIGINT, original)

--- a/src/pidcast/commands/transcribe.py
+++ b/src/pidcast/commands/transcribe.py
@@ -1,0 +1,197 @@
+"""Handler for ``pidcast transcribe`` (and the bare-input shortcut).
+
+Owns fuzzy name resolution, test-segment validation, duplicate detection, and
+the pause-aware run of the main transcription workflow. The analyze/diarize
+existing-file paths are now their own verbs (see analyze.py / diarize.py).
+"""
+
+import argparse
+import datetime
+import logging
+import time
+import uuid
+from pathlib import Path
+
+from ..config import OBSIDIAN_PATH, RUNS_FILE, resolve_output_dir
+from ..duplicate import DuplicateAction, prompt_duplicate_detected
+from ..utils import (
+    find_existing_transcription,
+    is_interactive,
+    log_error,
+    log_section,
+)
+from ..workflow import process_input_source, run_analyze_existing_mode
+
+logger = logging.getLogger(__name__)
+
+
+def cmd_transcribe(args: argparse.Namespace) -> None:
+    """Handle ``pidcast transcribe <input>`` (and bare ``pidcast <input>``)."""
+    # Resolve analysis type with fuzzy matching
+    if args.analysis_type and args.analysis_type != "executive_summary":
+        from ..utils import resolve_analysis_type
+
+        try:
+            resolved_type = resolve_analysis_type(args.analysis_type, args.prompts_file)
+            if resolved_type != args.analysis_type and args.verbose:
+                logger.info(f"Matched '{args.analysis_type}' → '{resolved_type}'")
+            args.analysis_type = resolved_type
+        except ValueError as e:
+            log_error(str(e))
+            return
+
+    # Resolve model name with fuzzy matching
+    if args.groq_model:
+        from ..utils import resolve_model_name
+
+        try:
+            resolved_model = resolve_model_name(args.groq_model)
+            if resolved_model != args.groq_model and args.verbose:
+                logger.info(f"Matched '{args.groq_model}' → '{resolved_model}'")
+            args.groq_model = resolved_model
+        except ValueError as e:
+            log_error(str(e))
+            return
+
+    # Resolve whisper model name to path (only needed for whisper provider)
+    transcription_provider = getattr(args, "transcription_provider", "whisper")
+    if args.whisper_model and transcription_provider == "whisper":
+        from ..transcription import resolve_whisper_model
+
+        try:
+            resolved = resolve_whisper_model(args.whisper_model)
+            if resolved != args.whisper_model and args.verbose:
+                logger.info(f"Whisper model: '{args.whisper_model}' -> {resolved}")
+            args.whisper_model = resolved
+        except Exception as e:
+            log_error(str(e))
+            return
+
+    # Set defaults for paths
+    output_dir = resolve_output_dir(args)
+    stats_file = Path(args.stats_file) if args.stats_file else RUNS_FILE
+
+    # Determine where analysis files should go
+    analysis_output_dir = Path(OBSIDIAN_PATH) if args.save_to_obsidian else output_dir
+
+    if args.save_to_obsidian and args.verbose:
+        logger.info(f"Analysis will be saved to Obsidian vault: {analysis_output_dir}")
+        logger.info(f"Transcripts will be saved to: {output_dir}")
+
+    # Initialize tracking variables
+    run_uid = str(uuid.uuid4())
+    run_timestamp = datetime.datetime.now().isoformat()
+    start_time = time.time()
+
+    # Validate test-segment options
+    test_segment = getattr(args, "test_segment", None)
+    start_at = getattr(args, "start_at", None)
+
+    if test_segment is not None:
+        if test_segment <= 0:
+            log_error("--test duration must be positive")
+            return
+        if test_segment > 30:
+            log_error("--test maximum is 30 minutes")
+            return
+
+    if start_at is not None:
+        if test_segment is None:
+            log_error("--start-at requires --test")
+            return
+        if start_at < 0:
+            log_error("--start-at must be non-negative")
+            return
+
+    if args.verbose:
+        log_section("Transcription Tool")
+        logger.info(f"Input: {args.input}")
+        logger.info(f"Run ID: {run_uid}")
+        logger.info(f"Timestamp: {run_timestamp}")
+
+    # Check for duplicate transcription (unless --force or --test is used)
+    if not args.force and test_segment is None:
+        prev_transcription = find_existing_transcription(stats_file, args.input, output_dir)
+
+        if prev_transcription:
+            # Handle non-interactive mode
+            if not is_interactive():
+                log_error(
+                    f"Duplicate detected: '{prev_transcription.video_title}' "
+                    f"was already transcribed on {prev_transcription.formatted_date}. "
+                    "Use --force to proceed anyway."
+                )
+                return
+
+            # Interactive mode: prompt user for action
+            action = prompt_duplicate_detected(prev_transcription, args.verbose)
+
+            if action == DuplicateAction.CANCEL:
+                logger.info("Operation cancelled.")
+                return
+
+            elif action == DuplicateAction.ANALYZE_EXISTING:
+                run_analyze_existing_mode(
+                    prev_transcription.transcript_path,
+                    args,
+                    output_dir,
+                    analysis_output_dir,
+                    stats_file,
+                    run_uid,
+                    run_timestamp,
+                    start_time,
+                )
+                return
+
+            elif action == DuplicateAction.RE_TRANSCRIBE:
+                logger.info("Re-transcribing video...")
+
+            elif action == DuplicateAction.FORCE_CONTINUE:
+                logger.info("Continuing with transcription...")
+
+    # Run the main transcription workflow under a pause-aware SIGINT handler.
+    _run_with_pause_handler(
+        lambda: process_input_source(
+            args.input,
+            args,
+            output_dir,
+            analysis_output_dir,
+            stats_file,
+            run_uid,
+            run_timestamp,
+            start_time,
+        )
+    )
+
+
+def _run_with_pause_handler(run_fn) -> None:
+    """Run ``run_fn`` with Ctrl-C wired to a clean transcription pause.
+
+    First Ctrl-C requests a pause (the whisper stream loop stops at the next
+    segment boundary and the job is checkpointed). A second Ctrl-C restores the
+    default handler and hard-quits.
+    """
+    import signal
+
+    from ..workflow import request_pause
+
+    state = {"count": 0}
+    original = signal.getsignal(signal.SIGINT)
+
+    def _handler(signum, frame):
+        state["count"] += 1
+        if state["count"] == 1:
+            logger.info(
+                "\nPausing transcription at the next segment boundary... "
+                "(Ctrl-C again to force quit)"
+            )
+            request_pause()
+        else:
+            signal.signal(signal.SIGINT, original)
+            raise KeyboardInterrupt
+
+    signal.signal(signal.SIGINT, _handler)
+    try:
+        run_fn()
+    finally:
+        signal.signal(signal.SIGINT, original)

--- a/src/pidcast/config.py
+++ b/src/pidcast/config.py
@@ -122,6 +122,46 @@ def ensure_data_dirs() -> None:
         directory.mkdir(parents=True, exist_ok=True)
 
 
+def resolve_output_dir(args: Any) -> Path:
+    """Resolve the transcript output directory.
+
+    Precedence (highest first):
+      1. ``--output-dir`` flag
+      2. ``config.yaml``'s ``output_dir`` (an explicit value the user set),
+         UNLESS it points at the legacy in-repo ``data/transcripts`` dir - older
+         configs pinned that absolute path before storage moved to the XDG data
+         dir, so we treat it as stale and fall through rather than sending new
+         transcripts back into the source tree.
+      3. the XDG ``TRANSCRIPTS_DIR`` default
+
+    Never falls back to the current working directory, so a run with no flag
+    lands artifacts in the canonical data dir instead of wherever you happen to
+    be standing.
+    """
+    flag = getattr(args, "output_dir", None)
+    if flag:
+        return Path(flag)
+
+    # Function-local import: config_manager imports constants from this module,
+    # so a top-level import would be circular.
+    from .config_manager import ConfigManager
+
+    configured = ConfigManager.load_config().get("output_dir")
+    if configured and not _is_legacy_repo_path(Path(configured), PROJECT_ROOT):
+        return Path(configured)
+
+    return TRANSCRIPTS_DIR
+
+
+def _is_legacy_repo_path(path: Path, project_root: Path) -> bool:
+    """True if ``path`` is the old in-repo data/transcripts location (now stale)."""
+    legacy = project_root / "data" / "transcripts"
+    try:
+        return path.resolve() == legacy.resolve()
+    except OSError:
+        return False
+
+
 # ----------------------------------------------------------------------------
 # Backward-compatibility aliases (deprecated; prefer the names above).
 # ----------------------------------------------------------------------------

--- a/src/pidcast/config_manager.py
+++ b/src/pidcast/config_manager.py
@@ -105,7 +105,7 @@ class ConfigManager:
                 f.write("# RSS feed cache duration (hours)\n")
                 f.write(f"feed_cache_hours: {config['feed_cache_hours']}\n\n")
                 f.write("# Chrome profile for cookie extraction (display name or directory name)\n")
-                f.write("# Run 'pidcast --list-chrome-profiles' to see available profiles\n")
+                f.write("# Run 'pidcast list profiles' to see available profiles\n")
                 f.write("chrome_profile: null\n")
 
             logger.info(f"Created default config at {CONFIG_FILE}")

--- a/src/pidcast/duplicate.py
+++ b/src/pidcast/duplicate.py
@@ -1,12 +1,15 @@
 """Duplicate-detection prompt UI.
 
 When a recording was already transcribed, ``prompt_duplicate_detected`` renders
-an interactive menu (re-transcribe / analyze existing / force / cancel). Lifted
-out of the CLI so the parser/dispatch layer stays thin and this UI concern lives
-on its own.
+a compact rounded panel (title, one-line metadata summary, bracketed-key
+choices) and resolves the user's choice with a single keypress via
+``ui.select_key``. Lifted out of the CLI so the parser/dispatch layer stays thin
+and this UI concern lives on its own.
 """
 
 from enum import Enum
+
+from . import ui
 
 
 class DuplicateAction(Enum):
@@ -18,132 +21,83 @@ class DuplicateAction(Enum):
     CANCEL = "cancel"
 
 
+# Returned key -> action. ``a`` is only offered when the transcript file exists.
+_KEY_TO_ACTION = {
+    "r": DuplicateAction.RE_TRANSCRIBE,
+    "a": DuplicateAction.ANALYZE_EXISTING,
+    "f": DuplicateAction.FORCE_CONTINUE,
+    "c": DuplicateAction.CANCEL,
+}
+
+
+def _build_summary(prev, transcript_exists: bool) -> str:
+    """One-line metadata summary: date · [analysis type] · transcript status."""
+    parts = [prev.formatted_date]
+    if prev.analysis_performed:
+        parts.append(prev.analysis_type or "analyzed")
+    parts.append("on disk" if transcript_exists else "file not found")
+    return " · ".join(parts)
+
+
 def prompt_duplicate_detected(
     prev,
     verbose: bool = False,
 ) -> DuplicateAction:
-    """Display duplicate detection UI and get user's choice.
+    """Display the duplicate-detection prompt and return the user's choice.
 
     Args:
         prev: Information about the previous transcription (PreviousTranscription)
-        verbose: Enable verbose output
+        verbose: Enable verbose output (currently unused; kept for call-site compat)
 
     Returns:
         User's selected action
     """
+    transcript_exists = prev.transcript_path.exists()
+    summary = _build_summary(prev, transcript_exists)
+
+    # Ordered choices; ``a`` (analyze existing) only when the file is on disk.
+    choices: list[tuple[str, str]] = [("r", "re-transcribe")]
+    if transcript_exists:
+        choices.append(("a", "analyze"))
+    choices.extend([("f", "force"), ("c", "cancel")])
 
     try:
+        from rich.box import ROUNDED
         from rich.console import Console
         from rich.panel import Panel
-        from rich.prompt import Prompt
-        from rich.table import Table
+        from rich.text import Text
     except ImportError:
-        return _prompt_duplicate_basic(prev)
+        # No rich: plain info lines, then select_key handles the keypress/fallback.
+        print("Already transcribed:")
+        print(f"  {prev.video_title}")
+        print(f"  {summary}")
+        choices_line = "   ".join(f"[{k}] {label}" for k, label in choices)
+        key = ui.select_key(choices_line, choices, default="c")
+        return _KEY_TO_ACTION[key]
 
     console = Console()
 
-    # Build info panel
-    console.print()
+    body = Text()
+    body.append(prev.video_title, style="bold")
+    body.append("\n")
+    body.append(summary, style="dim")
+    body.append("\n\n")
+    for i, (k, label) in enumerate(choices):
+        if i:
+            body.append("   ")
+        body.append(f"[{k}]", style="cyan")
+        body.append(f" {label}")
+
     console.print(
         Panel(
-            "[yellow bold]Duplicate Detected![/yellow bold]\n\n"
-            "This recording was previously transcribed.",
+            body,
+            title="Already transcribed",
             border_style="yellow",
+            box=ROUNDED,
         )
     )
 
-    # Show previous transcription details
-    table = Table(show_header=False, box=None, padding=(0, 2))
-    table.add_column(style="cyan", width=20)
-    table.add_column(style="white")
-
-    table.add_row("Title", prev.video_title)
-    table.add_row("Transcribed", prev.formatted_date)
-    table.add_row("File", prev.smart_filename)
-
-    # Check if transcript file still exists
-    transcript_exists = prev.transcript_path.exists()
-    if transcript_exists:
-        table.add_row("Status", "[green]Transcript file exists[/green]")
-    else:
-        table.add_row("Status", "[red]Transcript file not found[/red]")
-
-    if prev.analysis_performed:
-        table.add_row("Previous Analysis", prev.analysis_type or "Yes")
-
-    console.print(table)
-    console.print()
-
-    # Build options
-    console.print("[bold]What would you like to do?[/bold]")
-    console.print()
-    console.print("  [cyan]1[/cyan] - Re-transcribe the recording")
-
-    if transcript_exists:
-        console.print("  [cyan]2[/cyan] - Analyze existing transcript (skip re-transcription)")
-    else:
-        console.print("  [dim]2 - Analyze existing (unavailable - file not found)[/dim]")
-
-    console.print("  [cyan]3[/cyan] - Continue anyway (force re-transcription)")
-    console.print("  [cyan]4[/cyan] - Cancel")
-    console.print()
-
-    # Get choice
-    valid_choices = ["1", "2", "3", "4"] if transcript_exists else ["1", "3", "4"]
-    while True:
-        choice = Prompt.ask(
-            "Enter choice",
-            choices=valid_choices,
-            default="4",
-        )
-
-        if choice == "1":
-            return DuplicateAction.RE_TRANSCRIBE
-        elif choice == "2" and transcript_exists:
-            return DuplicateAction.ANALYZE_EXISTING
-        elif choice == "3":
-            return DuplicateAction.FORCE_CONTINUE
-        elif choice == "4":
-            return DuplicateAction.CANCEL
-
-
-def _prompt_duplicate_basic(prev) -> DuplicateAction:
-    """Basic fallback prompt without rich.
-
-    Args:
-        prev: Information about the previous transcription (PreviousTranscription)
-    """
-    print("\n" + "=" * 60)
-    print("DUPLICATE DETECTED!")
-    print("=" * 60)
-    print(f"Title: {prev.video_title}")
-    print(f"Previously transcribed: {prev.formatted_date}")
-    print(f"File: {prev.smart_filename}")
-    print()
-    print("Options:")
-    print("  1 - Re-transcribe the recording")
-    print("  2 - Analyze existing transcript")
-    print("  3 - Continue anyway")
-    print("  4 - Cancel")
-    print()
-
-    transcript_exists = prev.transcript_path.exists()
-    valid_choices = {"1", "3", "4"}
-    if transcript_exists:
-        valid_choices.add("2")
-    else:
-        print("  (Option 2 unavailable - transcript file not found)")
-
-    while True:
-        choice = input("Enter choice [4]: ").strip() or "4"
-        if choice in valid_choices:
-            break
-        print(f"Invalid choice. Please enter: {', '.join(sorted(valid_choices))}")
-
-    mapping = {
-        "1": DuplicateAction.RE_TRANSCRIBE,
-        "2": DuplicateAction.ANALYZE_EXISTING,
-        "3": DuplicateAction.FORCE_CONTINUE,
-        "4": DuplicateAction.CANCEL,
-    }
-    return mapping[choice]
+    # Plain hint string only used by the non-TTY fallback path inside select_key.
+    choices_line = "   ".join(f"[{k}] {label}" for k, label in choices)
+    key = ui.select_key(choices_line, choices, default="c")
+    return _KEY_TO_ACTION[key]

--- a/src/pidcast/duplicate.py
+++ b/src/pidcast/duplicate.py
@@ -1,0 +1,149 @@
+"""Duplicate-detection prompt UI.
+
+When a recording was already transcribed, ``prompt_duplicate_detected`` renders
+an interactive menu (re-transcribe / analyze existing / force / cancel). Lifted
+out of the CLI so the parser/dispatch layer stays thin and this UI concern lives
+on its own.
+"""
+
+from enum import Enum
+
+
+class DuplicateAction(Enum):
+    """User's choice when duplicate transcription is detected."""
+
+    RE_TRANSCRIBE = "retranscribe"
+    ANALYZE_EXISTING = "analyze"
+    FORCE_CONTINUE = "force"
+    CANCEL = "cancel"
+
+
+def prompt_duplicate_detected(
+    prev,
+    verbose: bool = False,
+) -> DuplicateAction:
+    """Display duplicate detection UI and get user's choice.
+
+    Args:
+        prev: Information about the previous transcription (PreviousTranscription)
+        verbose: Enable verbose output
+
+    Returns:
+        User's selected action
+    """
+
+    try:
+        from rich.console import Console
+        from rich.panel import Panel
+        from rich.prompt import Prompt
+        from rich.table import Table
+    except ImportError:
+        return _prompt_duplicate_basic(prev)
+
+    console = Console()
+
+    # Build info panel
+    console.print()
+    console.print(
+        Panel(
+            "[yellow bold]Duplicate Detected![/yellow bold]\n\n"
+            "This recording was previously transcribed.",
+            border_style="yellow",
+        )
+    )
+
+    # Show previous transcription details
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column(style="cyan", width=20)
+    table.add_column(style="white")
+
+    table.add_row("Title", prev.video_title)
+    table.add_row("Transcribed", prev.formatted_date)
+    table.add_row("File", prev.smart_filename)
+
+    # Check if transcript file still exists
+    transcript_exists = prev.transcript_path.exists()
+    if transcript_exists:
+        table.add_row("Status", "[green]Transcript file exists[/green]")
+    else:
+        table.add_row("Status", "[red]Transcript file not found[/red]")
+
+    if prev.analysis_performed:
+        table.add_row("Previous Analysis", prev.analysis_type or "Yes")
+
+    console.print(table)
+    console.print()
+
+    # Build options
+    console.print("[bold]What would you like to do?[/bold]")
+    console.print()
+    console.print("  [cyan]1[/cyan] - Re-transcribe the recording")
+
+    if transcript_exists:
+        console.print("  [cyan]2[/cyan] - Analyze existing transcript (skip re-transcription)")
+    else:
+        console.print("  [dim]2 - Analyze existing (unavailable - file not found)[/dim]")
+
+    console.print("  [cyan]3[/cyan] - Continue anyway (force re-transcription)")
+    console.print("  [cyan]4[/cyan] - Cancel")
+    console.print()
+
+    # Get choice
+    valid_choices = ["1", "2", "3", "4"] if transcript_exists else ["1", "3", "4"]
+    while True:
+        choice = Prompt.ask(
+            "Enter choice",
+            choices=valid_choices,
+            default="4",
+        )
+
+        if choice == "1":
+            return DuplicateAction.RE_TRANSCRIBE
+        elif choice == "2" and transcript_exists:
+            return DuplicateAction.ANALYZE_EXISTING
+        elif choice == "3":
+            return DuplicateAction.FORCE_CONTINUE
+        elif choice == "4":
+            return DuplicateAction.CANCEL
+
+
+def _prompt_duplicate_basic(prev) -> DuplicateAction:
+    """Basic fallback prompt without rich.
+
+    Args:
+        prev: Information about the previous transcription (PreviousTranscription)
+    """
+    print("\n" + "=" * 60)
+    print("DUPLICATE DETECTED!")
+    print("=" * 60)
+    print(f"Title: {prev.video_title}")
+    print(f"Previously transcribed: {prev.formatted_date}")
+    print(f"File: {prev.smart_filename}")
+    print()
+    print("Options:")
+    print("  1 - Re-transcribe the recording")
+    print("  2 - Analyze existing transcript")
+    print("  3 - Continue anyway")
+    print("  4 - Cancel")
+    print()
+
+    transcript_exists = prev.transcript_path.exists()
+    valid_choices = {"1", "3", "4"}
+    if transcript_exists:
+        valid_choices.add("2")
+    else:
+        print("  (Option 2 unavailable - transcript file not found)")
+
+    while True:
+        choice = input("Enter choice [4]: ").strip() or "4"
+        if choice in valid_choices:
+            break
+        print(f"Invalid choice. Please enter: {', '.join(sorted(valid_choices))}")
+
+    mapping = {
+        "1": DuplicateAction.RE_TRANSCRIBE,
+        "2": DuplicateAction.ANALYZE_EXISTING,
+        "3": DuplicateAction.FORCE_CONTINUE,
+        "4": DuplicateAction.CANCEL,
+    }
+    return mapping[choice]

--- a/src/pidcast/resume.py
+++ b/src/pidcast/resume.py
@@ -23,29 +23,25 @@ logger = logging.getLogger(__name__)
 
 def _reconstruct_args(manifest: JobManifest):
     """Rebuild an argparse.Namespace: full defaults overlaid with persisted flags."""
-    # Parse with a throwaway input to populate every default, then overlay.
-    import sys
+    from .cli import build_transcribe_namespace
 
-    from .cli import parse_arguments
+    # A fully-defaulted transcribe Namespace (no sys.argv mutation).
+    args = build_transcribe_namespace(manifest.source_wav_path.as_posix())
 
-    saved_argv = sys.argv
-    try:
-        sys.argv = ["pidcast", manifest.source_wav_path.as_posix()]
-        args = parse_arguments()
-    finally:
-        sys.argv = saved_argv
-
+    # Overlay only the flags that belong to the transcribe surface. Legacy
+    # manifests may carry dropped dests (e.g. analyze_existing/diarize_existing)
+    # from before the verb-grammar refactor; filtering against the live
+    # namespace prevents those dead flags from resurrecting onto args.
     for key, value in manifest.cli_args.items():
-        setattr(args, key, value)
+        if hasattr(args, key):
+            setattr(args, key, value)
 
     # Resume always points at the job-dir source WAV (a local file), forces past
     # duplicate detection, and disables test-segment.
-    args.input_source = str(manifest.source_wav_path)
+    args.input = str(manifest.source_wav_path)
     args.force = True
     args.test_segment = None
     args.start_at = None
-    args.analyze_existing = None
-    args.diarize_existing = None
     args.resume_job_id = manifest.job_id
     args.no_checkpoint = False
     # Keep the checkpoint across a resume that itself gets paused again.
@@ -112,7 +108,7 @@ def resume_job(manifest: JobManifest) -> None:
             manifest.cli_args.get("whisper_model") or manifest.model
         )
 
-    from .cli import _run_with_pause_handler
+    from .commands.transcribe import _run_with_pause_handler
     from .workflow import process_input_source
 
     # Honor the manifest's pinned output_dir (reconstructed onto args); fall back
@@ -137,7 +133,7 @@ def resume_job(manifest: JobManifest) -> None:
 
     _run_with_pause_handler(
         lambda: process_input_source(
-            args.input_source,
+            args.input,
             args,
             output_dir,
             analysis_output_dir,
@@ -148,3 +144,36 @@ def resume_job(manifest: JobManifest) -> None:
             video_info_override=video_info_override,
         )
     )
+
+
+def run_resume(args=None) -> None:
+    """Resume a paused/interrupted transcription job (``pidcast resume [job-id]``)."""
+    from .checkpoint import DONE, find_resumable_jobs
+
+    job_arg = getattr(args, "job_id", None)
+
+    jobs = find_resumable_jobs()
+    if not jobs:
+        logger.info("No resumable jobs found.")
+        return
+
+    manifest: JobManifest | None = None
+    if job_arg:
+        manifest = next((j for j in jobs if j.job_id.startswith(job_arg)), None)
+        if manifest is None:
+            logger.error(f"No resumable job matching '{job_arg}'.")
+            return
+    elif len(jobs) == 1:
+        manifest = jobs[0]
+    else:
+        logger.info("Multiple resumable jobs - pass a job id to pick one:\n")
+        for j in jobs:
+            phase = "diarization" if j.transcription.status == DONE else "transcription"
+            title = (j.video_info or {}).get("title", j.input_source)
+            logger.info(
+                f"  {j.job_id}  [{phase}]  {title}  "
+                f"({j.transcription.segment_count} segments, updated {j.updated_at})"
+            )
+        return
+
+    resume_job(manifest)

--- a/src/pidcast/setup.py
+++ b/src/pidcast/setup.py
@@ -154,7 +154,7 @@ def check_data_dirs() -> CheckResult:
         "data dir",
         True,
         f"ok ({DATA_DIR})",
-        hint="Override with PIDCAST_DATA_DIR or XDG_DATA_HOME. See 'pidcast paths'.",
+        hint="Override with PIDCAST_DATA_DIR or XDG_DATA_HOME. See 'pidcast info'.",
         required=False,
     )
 
@@ -278,3 +278,155 @@ def write_env_var(key: str, value: str) -> None:
         lines.append(f"{key}={value}")
 
     ENV_FILE.write_text("\n".join(lines) + "\n")
+
+
+# ============================================================================
+# CLI HANDLERS (pidcast doctor / pidcast setup)
+# ============================================================================
+
+
+def run_doctor(args=None) -> None:
+    """Run health checks and display configuration status (``pidcast doctor``)."""
+    from .config import RUNS_FILE
+    from .utils import prune_phantom_stats
+
+    prune_stats = bool(getattr(args, "prune_stats", False))
+
+    print("\npidcast doctor")
+    print("=" * 40)
+
+    if prune_stats:
+        removed = prune_phantom_stats(RUNS_FILE)
+        print(f"  Pruned {removed} phantom stats entr(y/ies) with a missing transcript.\n")
+
+    checks = run_all_checks()
+    max_name = max(len(c.name) for c in checks)
+
+    for check in checks:
+        dots = "." * (max_name + 6 - len(check.name))
+        if check.ok:
+            print(f"  {check.name} {dots} {check.detail}")
+        else:
+            label = "MISSING" if check.required else "not set"
+            msg = check.detail if check.detail != "not set" else label
+            print(f"  {check.name} {dots} {msg}")
+            if check.hint:
+                print(f"    -> {check.hint}")
+
+    status, tip = determine_status(checks)
+    print(f"\n  Status: {status}")
+    if tip:
+        print(f"  Tip: {tip}")
+    print()
+
+
+def run_setup(args=None) -> None:
+    """Interactive setup wizard for first-time users (``pidcast setup``)."""
+    print("\npidcast setup")
+    print("=" * 40)
+
+    # Step 1: System dependencies
+    print("\nStep 1/3: Checking system dependencies...\n")
+
+    ffmpeg = check_ffmpeg()
+    if ffmpeg.ok:
+        print(f"  ffmpeg: {ffmpeg.detail}")
+    else:
+        print("  ffmpeg: not found")
+        print("    Install: brew install ffmpeg (macOS) or apt install ffmpeg (Linux)")
+        print("    Then re-run: pidcast setup")
+        return
+
+    whisper = check_whisper()
+    whisper_model = check_whisper_model()
+    use_elevenlabs = False
+
+    if whisper.ok and whisper_model.ok:
+        print(f"  whisper.cpp: {whisper.detail}")
+        print(f"  whisper model: {whisper_model.detail}")
+        vad = check_vad_model()
+        if vad.ok:
+            print(f"  VAD model: {vad.detail}")
+        else:
+            print("  VAD model: not found (optional, enables --vad anti-hallucination)")
+            print("    Download: cd whisper.cpp && bash models/download-vad-model.sh silero-v5.1.2")
+            print("    Then set in .env: WHISPER_VAD_MODEL=/path/to/ggml-silero-v5.1.2.bin")
+    else:
+        print("  whisper.cpp: not configured")
+        print("\n  whisper.cpp is needed for local (private) transcription.")
+        print("  You can skip it and use ElevenLabs (cloud) instead.\n")
+        print("  [1] I'll set up whisper.cpp myself (see README for instructions)")
+        print("  [2] Skip - use ElevenLabs cloud transcription")
+        try:
+            choice = input("\n  > ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\n  Setup cancelled.")
+            return
+        if choice == "2":
+            use_elevenlabs = True
+        else:
+            print("\n  To set up whisper.cpp:")
+            print("    1. git clone https://github.com/ggerganov/whisper.cpp.git")
+            print("    2. cd whisper.cpp && make")
+            print("    3. bash models/download-ggml-model.sh base.en")
+            print("    4. Set in .env: WHISPER_CPP_PATH=/path/to/whisper.cpp/build/bin/whisper-cli")
+            print("    5. Set in .env: WHISPER_MODEL=/path/to/whisper.cpp/models/ggml-base.en.bin")
+            print("    6. Re-run: pidcast setup")
+            return
+
+    # Step 2: API keys
+    print("\nStep 2/3: API keys\n")
+
+    # Groq (for analysis)
+    groq = check_env_var("GROQ_API_KEY", "GROQ_API_KEY")
+    if groq.ok:
+        print(f"  GROQ_API_KEY: {groq.detail}")
+    else:
+        print("  GROQ_API_KEY: not set (needed for AI analysis)")
+        print("  Get a free key at: https://console.groq.com/")
+        try:
+            key = input("  Paste your key (or press Enter to skip): ").strip()
+        except (EOFError, KeyboardInterrupt):
+            key = ""
+        if key:
+            write_env_var("GROQ_API_KEY", key)
+            print("  Saved to .env")
+        else:
+            print("  Skipped - transcription will work, but AI analysis will be disabled")
+
+    # ElevenLabs (if chosen or if no whisper)
+    if use_elevenlabs:
+        el = check_env_var("ELEVENLABS_API_KEY", "ELEVENLABS_API_KEY")
+        if el.ok:
+            print(f"  ELEVENLABS_API_KEY: {el.detail}")
+        else:
+            print("\n  ELEVENLABS_API_KEY: not set (needed for cloud transcription)")
+            print("  Get a key at: https://elevenlabs.io/")
+            try:
+                key = input("  Paste your key: ").strip()
+            except (EOFError, KeyboardInterrupt):
+                key = ""
+            if key:
+                write_env_var("ELEVENLABS_API_KEY", key)
+                print("  Saved to .env")
+            else:
+                print("  Without this key, transcription won't work.")
+                print("  Add it to .env later: ELEVENLABS_API_KEY=your_key")
+                return
+
+    # Step 3: Summary
+    print("\nStep 3/3: Ready!\n")
+
+    if not ENV_FILE.exists():
+        print(f"  Note: .env file created at {ENV_FILE}")
+
+    if use_elevenlabs:
+        print("  Provider: ElevenLabs (cloud)")
+        print("\n  Try it:")
+        print('    pidcast "https://youtube.com/watch?v=VIDEO_ID"')
+    else:
+        print("  Provider: whisper.cpp (local)")
+        print("\n  Try it:")
+        print('    pidcast "https://youtube.com/watch?v=VIDEO_ID"')
+
+    print()

--- a/src/pidcast/transcription.py
+++ b/src/pidcast/transcription.py
@@ -4,7 +4,6 @@ import contextlib
 import logging
 import re
 import subprocess
-import time
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
@@ -615,9 +614,10 @@ def _run_whisper_streaming(
     whether a duration estimate is available. whisper.cpp prints each completed
     segment to stdout and flushes, so we parse those lines live.
 
-    In verbose mode stdout is inherited (whisper prints directly) so we cannot
-    parse segments - pause still works via process polling, but per-segment
-    checkpointing does not. Callers needing checkpointing run non-verbose.
+    stdout is always captured (even in verbose) so we can parse segments and
+    keep the progress display stable; verbose surfaces the raw non-segment lines
+    above the display (or to the debug log) rather than inheriting the terminal.
+    This means per-segment checkpointing and pause now work in verbose too.
 
     Raises:
         TranscriptionPaused: if ``pause_check`` returns True mid-run.
@@ -636,10 +636,31 @@ def _run_whisper_streaming(
         total = int(estimated_duration * 1000)
 
     label = "Resuming transcription" if offset_base > 0 else "Transcribing"
+
+    # Prefer the run's single shared Live display when one is active: drive a
+    # task on it instead of spawning a competing Progress. Fall back to a local
+    # Progress only for standalone calls with no active reporter.
+    from .ui import active_reporter
+
+    reporter = active_reporter()
     progress_ctx = None
     progress = None
     task = None
-    if show_progress and not verbose:
+    shared_task = None
+
+    import sys
+
+    stdout_is_tty = False
+    with contextlib.suppress(Exception):
+        stdout_is_tty = bool(sys.stdout.isatty())
+
+    if reporter is not None and reporter.is_live:
+        shared_task = reporter.task(f"{label}...", total=total)
+        if total and offset_base > 0:
+            shared_task.update(completed=min(offset_base, total - 1))
+    elif show_progress and stdout_is_tty:
+        # Standalone (no active reporter) AND a real terminal: own a local
+        # Progress. Off a TTY (piped/CI) we stay silent so no bar leaks into logs.
         try:
             from rich.progress import (
                 BarColumn,
@@ -664,11 +685,12 @@ def _run_whisper_streaming(
         except ImportError:
             logger.info(f"{label} (install 'rich' for progress display)...")
 
-    # Verbose: inherit stdout so whisper prints directly; only poll for pause.
-    stdout_target = None if verbose else subprocess.PIPE
+    # Always capture stdout so we can parse segments (and keep the bar stable);
+    # verbose surfaces the raw lines above the display via the reporter instead
+    # of inheriting the terminal, so the progress bar is never pushed down.
     proc = subprocess.Popen(
         command,
-        stdout=stdout_target,
+        stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
         bufsize=1,
@@ -681,6 +703,13 @@ def _run_whisper_streaming(
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait()
+
+    def _advance(completed: int) -> None:
+        """Push a position update to whichever display is active."""
+        if shared_task is not None:
+            shared_task.update(completed=completed)
+        elif progress is not None and task is not None and total:
+            progress.update(task, completed=completed)
 
     last_to_ms = offset_base
     try:
@@ -700,28 +729,34 @@ def _run_whisper_streaming(
 
                 seg = parse_whisper_segment_line(line)
                 if seg is None:
+                    # Non-segment line: in verbose, surface it above the live
+                    # display (or to the log) instead of dropping it silently.
+                    if verbose:
+                        stripped = line.rstrip()
+                        if stripped:
+                            if reporter is not None and reporter.is_live:
+                                reporter.log(stripped, style="dim")
+                            else:
+                                logger.debug(stripped)
                     continue
                 last_to_ms = seg["to_ms"]
                 if segment_callback is not None:
                     segment_callback(seg)
-                if progress is not None and task is not None and total:
-                    progress.update(task, completed=min(seg["to_ms"], total - 1))
-        else:
-            # Verbose path: no stdout to read; poll for pause.
-            while proc.poll() is None:
-                if pause_check is not None and pause_check():
-                    _terminate_for_pause()
-                    raise TranscriptionPaused(last_offset_ms=last_to_ms)
-                time.sleep(0.2)
+                if total:
+                    _advance(min(seg["to_ms"], total - 1))
 
         proc.wait()
-        if progress is not None and task is not None and total:
-            progress.update(task, completed=total)
+        if total:
+            _advance(total)
 
         if proc.returncode != 0:
             stderr = proc.stderr.read() if proc.stderr else ""
             raise subprocess.CalledProcessError(proc.returncode, command, stderr=stderr)
     finally:
+        # Hide the finished shared task so the completed bar isn't redrawn under
+        # the run summary; stop a locally-owned Progress.
+        if shared_task is not None:
+            shared_task.finish()
         if progress_ctx is not None:
             progress_ctx.stop()
         if proc.stdout is not None:
@@ -856,8 +891,9 @@ def run_whisper_transcription(
             pause_check=pause_check,
         )
 
-        if verbose:
-            logger.info("✓ Transcription completed successfully.")
+        # The user-facing completion line is emitted once at the workflow level;
+        # keep this as a debug breadcrumb so verbose runs don't double-report it.
+        logger.debug("whisper transcription returned successfully")
 
         return True
 

--- a/src/pidcast/ui.py
+++ b/src/pidcast/ui.py
@@ -171,3 +171,97 @@ class RunReporter:
             self._console.print(f"[red]✗ {message}[/red]")
         else:
             logger.error(message)
+
+
+# ---------------------------------------------------------------------------
+# Single-keypress selector
+# ---------------------------------------------------------------------------
+
+
+def _read_raw_key() -> str:
+    """Read one keypress from stdin in cbreak mode and return it as a string.
+
+    Restores the terminal in a ``finally`` so a ``KeyboardInterrupt`` mid-read
+    never leaves stdin in raw mode. Returns ``""`` on EOF. Raises if termios is
+    unavailable or the terminal can't enter cbreak (caller falls back to line
+    input).
+    """
+    import sys
+    import termios
+    import tty
+
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    try:
+        tty.setcbreak(fd)
+        ch = sys.stdin.read(1)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    return ch
+
+
+def select_key(prompt: str, choices: list[tuple[str, str]], *, default: str) -> str:
+    """Single-keypress selector. Returns the chosen key (lowercase).
+
+    Args:
+        prompt: Hint line printed once in the non-TTY fallback (may be empty).
+        choices: Ordered ``(key, label)`` pairs; each ``key`` is one lowercase char.
+        default: Key returned on Enter / empty input. Must be a choice key.
+
+    Behaviour:
+        - TTY: reads one raw key (no Enter). Case-insensitive match. Enter selects
+          the default. Esc / Ctrl-C / EOF select the cancel key (``"c"`` if present,
+          else the default). An unrecognized key re-reads until a valid/exit key.
+        - Non-TTY or no termios: prints the hint once, then loops on ``input()``;
+          the first character is matched the same way. Empty line → default,
+          EOF → cancel/default.
+    """
+    import sys
+
+    keys = {k.lower() for k, _ in choices}
+    cancel = "c" if "c" in keys else default
+
+    def _resolve(ch: str) -> str | None:
+        """Map a single character to a choice key, or None to re-read."""
+        if ch in ("\r", "\n"):
+            return default
+        if ch in ("\x1b", "\x03"):  # Esc, Ctrl-C
+            return cancel
+        low = ch.lower()
+        if low in keys:
+            return low
+        return None
+
+    use_tty = False
+    try:
+        use_tty = bool(sys.stdin.isatty())
+    except Exception:
+        use_tty = False
+
+    if use_tty:
+        try:
+            while True:
+                ch = _read_raw_key()
+                if ch == "":  # EOF
+                    return cancel
+                resolved = _resolve(ch)
+                if resolved is not None:
+                    return resolved
+        except Exception:
+            # termios import / tcgetattr failure (e.g. Windows, odd terminal) ->
+            # fall through to the line-based input() fallback below.
+            pass
+
+    # Non-TTY / no-termios fallback: line-based input.
+    if prompt:
+        print(prompt)
+    while True:
+        try:
+            line = input()
+        except EOFError:
+            return cancel
+        if line == "":
+            return default
+        resolved = _resolve(line[0])
+        if resolved is not None:
+            return resolved

--- a/src/pidcast/ui.py
+++ b/src/pidcast/ui.py
@@ -1,0 +1,173 @@
+"""Single-owner run reporter for polished, stable CLI output.
+
+One run owns ONE rich ``Console`` + ``Live`` + ``Progress`` via ``RunReporter``.
+The Live region shows the current phase and a progress bar that updates in place;
+completed steps are logged ABOVE it so the bar never gets "pushed down" by
+interleaved prints. In a non-TTY environment (pipes, CI, pytest) the reporter
+degrades to plain ``logging`` and never starts a Live region.
+
+Producers (whisper streaming, analysis chunking) and the ``log_*`` helpers reach
+the in-flight reporter via the module-global ``active_reporter()`` so they render
+through the one display instead of spawning competing ones.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+
+logger = logging.getLogger(__name__)
+
+# The reporter currently driving the run (or None). Producers consult this to
+# attach to the shared progress display instead of creating their own.
+_ACTIVE: RunReporter | None = None
+
+
+def active_reporter() -> RunReporter | None:
+    """Return the reporter driving the current run, or None."""
+    return _ACTIVE
+
+
+def _stdout_is_tty() -> bool:
+    import sys
+
+    try:
+        return bool(sys.stdout.isatty())
+    except Exception:
+        return False
+
+
+class _TaskHandle:
+    """Handle to one task on the shared Progress.
+
+    Always safe to call: when there's no live Progress (non-TTY), update() is a
+    no-op so producers can drive it unconditionally.
+    """
+
+    def __init__(self, progress=None, task_id=None):
+        self._progress = progress
+        self._task_id = task_id
+
+    def update(self, *, completed=None, total=None, description=None) -> None:
+        if self._progress is None or self._task_id is None:
+            return
+        kwargs = {}
+        if completed is not None:
+            kwargs["completed"] = completed
+        if total is not None:
+            kwargs["total"] = total
+        if description is not None:
+            kwargs["description"] = description
+        if kwargs:
+            self._progress.update(self._task_id, **kwargs)
+
+    def finish(self) -> None:
+        """Hide this task so a finished bar isn't redrawn under later output."""
+        if self._progress is None or self._task_id is None:
+            return
+        with contextlib.suppress(Exception):
+            self._progress.update(self._task_id, visible=False)
+
+
+class RunReporter:
+    """Owns the single Live display for one run.
+
+    Use as a context manager. While active it is registered as the global
+    ``active_reporter()``. On a TTY it starts a rich ``Live`` wrapping a single
+    ``Progress``; off a TTY it stays plain and routes everything through
+    ``logging`` so piped/CI output is clean and never carries control codes.
+    """
+
+    def __init__(self, verbose: bool = False, force_plain: bool = False):
+        self.verbose = verbose
+        self._force_plain = force_plain
+        self._prev_active: RunReporter | None = None
+        self._live = None
+        self._progress = None
+        self.is_live = False
+
+    # -- context management ---------------------------------------------------
+
+    def __enter__(self) -> RunReporter:
+        global _ACTIVE
+        self._prev_active = _ACTIVE
+        _ACTIVE = self
+
+        if not self._force_plain and _stdout_is_tty():
+            self._start_live()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        global _ACTIVE
+        if self._live is not None:
+            with contextlib.suppress(Exception):
+                self._live.stop()
+            self._live = None
+        self.is_live = False
+        _ACTIVE = self._prev_active
+
+    def _start_live(self) -> None:
+        try:
+            from rich.console import Console
+            from rich.live import Live
+            from rich.progress import (
+                BarColumn,
+                Progress,
+                SpinnerColumn,
+                TextColumn,
+                TimeElapsedColumn,
+                TimeRemainingColumn,
+            )
+        except ImportError:
+            return  # rich missing -> stay plain
+
+        self._console = Console()
+        self._progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[cyan]{task.description}"),
+            BarColumn(),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            TextColumn("[dim]elapsed[/dim]"),
+            TimeElapsedColumn(),
+            TextColumn("[dim]eta[/dim]"),
+            TimeRemainingColumn(),
+            console=self._console,
+            transient=False,
+        )
+        self._live = Live(self._progress, console=self._console, refresh_per_second=10)
+        self._live.start()
+        self.is_live = True
+
+    # -- producer API ---------------------------------------------------------
+
+    def task(self, description: str, total: int | None = None) -> _TaskHandle:
+        """Add a task to the shared Progress and return a safe handle."""
+        if self._progress is None:
+            return _TaskHandle()
+        task_id = self._progress.add_task(description, total=total)
+        return _TaskHandle(self._progress, task_id)
+
+    # -- log API (above the Live region) --------------------------------------
+
+    def log(self, message: str, style: str | None = None) -> None:
+        """Emit a completed-step line above the Live region."""
+        if self.is_live and self._console is not None:
+            self._console.print(message if style is None else f"[{style}]{message}[/{style}]")
+        else:
+            logger.info(message)
+
+    def phase(self, label: str) -> None:
+        """Mark the start of a phase (a clean log line / rule)."""
+        self.log(label, style="bold")
+
+    def warn(self, message: str) -> None:
+        if self.is_live and self._console is not None:
+            self._console.print(f"[yellow]⚠ {message}[/yellow]")
+        else:
+            logger.warning(message)
+
+    def error(self, message: str) -> None:
+        if self.is_live and self._console is not None:
+            self._console.print(f"[red]✗ {message}[/red]")
+        else:
+            logger.error(message)

--- a/src/pidcast/utils.py
+++ b/src/pidcast/utils.py
@@ -760,11 +760,12 @@ def resolve_analysis_type(user_input: str, prompts_file: Path | None = None) -> 
         if suggestion:
             raise ValueError(
                 f"Unknown analysis type: '{user_input}'. Did you mean '{suggestion}'?\n"
-                f"Use -L to list all available types."
+                f"Run 'pidcast list analyses' to list all available types."
             )
         else:
             raise ValueError(
-                f"Unknown analysis type: '{user_input}'.\nUse -L to list all available types."
+                f"Unknown analysis type: '{user_input}'.\n"
+                f"Run 'pidcast list analyses' to list all available types."
             )
 
     except FileNotFoundError:
@@ -833,11 +834,12 @@ def resolve_model_name(user_input: str, models_file: Path | None = None) -> str:
         if suggestion:
             raise ValueError(
                 f"Unknown model: '{user_input}'. Did you mean '{suggestion}'?\n"
-                f"Use -M to list all available models."
+                f"Run 'pidcast list models' to list all available models."
             )
         else:
             raise ValueError(
-                f"Unknown model: '{user_input}'.\nUse -M to list all available models."
+                f"Unknown model: '{user_input}'.\n"
+                f"Run 'pidcast list models' to list all available models."
             )
 
     except FileNotFoundError:

--- a/src/pidcast/utils.py
+++ b/src/pidcast/utils.py
@@ -115,26 +115,54 @@ def setup_logging(verbose: bool = False) -> None:
     _LOGGING_CONFIGURED = True
 
 
+def _reporter():
+    """The active RunReporter, or None. Function-local import avoids cycles."""
+    from .ui import active_reporter
+
+    return active_reporter()
+
+
 def log_success(message: str) -> None:
     """Log success message with checkmark."""
-    logger.info(f"✓ {message}")
+    reporter = _reporter()
+    if reporter is not None and reporter.is_live:
+        reporter.log(f"✓ {message}", style="green")
+    else:
+        logger.info(f"✓ {message}")
 
 
 def log_error(message: str) -> None:
     """Log error message with X mark."""
-    logger.error(f"✗ {message}")
+    reporter = _reporter()
+    if reporter is not None and reporter.is_live:
+        reporter.error(message)
+    else:
+        logger.error(f"✗ {message}")
 
 
 def log_warning(message: str) -> None:
     """Log warning message."""
-    logger.warning(f"⚠ {message}")
+    reporter = _reporter()
+    if reporter is not None and reporter.is_live:
+        reporter.warn(message)
+    else:
+        logger.warning(f"⚠ {message}")
 
 
 def log_section(title: str, width: int = 60) -> None:
-    """Log section header with separator line."""
-    logger.info(f"\n{'=' * width}")
-    logger.info(title)
-    logger.info(f"{'=' * width}")
+    """Log a section header.
+
+    With an active Live reporter, render a single clean phase line above the
+    progress region; otherwise fall back to the classic separator-bracketed
+    header (kept for no-Live commands and piped output).
+    """
+    reporter = _reporter()
+    if reporter is not None and reporter.is_live:
+        reporter.phase(title)
+    else:
+        logger.info(f"\n{'=' * width}")
+        logger.info(title)
+        logger.info(f"{'=' * width}")
 
 
 # ============================================================================

--- a/src/pidcast/workflow.py
+++ b/src/pidcast/workflow.py
@@ -953,7 +953,7 @@ def process_input_source(
             if video_info_override.upload_date:
                 video_info.upload_date = video_info_override.upload_date
             # Preserve the original source url (resume): otherwise the front matter
-            # would point at the checkpoint's source.wav, breaking --diarize-existing.
+            # would point at the checkpoint's source.wav, breaking `pidcast diarize`.
             if video_info_override.webpage_url:
                 video_info.webpage_url = video_info_override.webpage_url
 
@@ -1150,7 +1150,7 @@ def process_input_source(
                 f"Segment: {test_segment:.0f} min"
                 + (f" from {start_at:.0f}:00" if start_at else "")
             )
-            logger.info("\nResults look good? Run without --test-segment for full transcription.")
+            logger.info("\nResults look good? Run without --test for full transcription.")
             success = True
             return True
 
@@ -1385,7 +1385,7 @@ def process_input_source(
                     pass  # Best-effort fallback
 
             logger.info("Retry diarization without re-transcribing:")
-            logger.info(f"  pidcast --diarize-existing {fallback_md}")
+            logger.info(f"  pidcast diarize {fallback_md}")
         if args.verbose:
             traceback.print_exc()
         return False

--- a/src/pidcast/workflow.py
+++ b/src/pidcast/workflow.py
@@ -923,14 +923,12 @@ def process_input_source(
                 start_offset=segment_offset,
                 max_duration=segment_duration,
             )
-            logger.info("\n✓ Local file processed successfully!")
+            log_success("Processed local file")
         elif is_apple_podcasts_url(source):
             logger.info("Resolving Apple Podcasts URL...")
             audio_url, video_info = resolve_apple_podcasts_url(source, args.verbose)
-            logger.info(f"Found: {video_info.title}")
-            logger.info("Downloading podcast audio...")
             audio_file, _ = download_audio(audio_url, "temp_audio.%(ext)s", args.verbose)
-            logger.info("\n✓ Audio downloaded successfully!")
+            log_success("Downloaded audio")
         else:
             logger.info("Downloading audio from YouTube...")
             audio_file, video_info = download_audio(
@@ -942,7 +940,7 @@ def process_input_source(
                 cookies=getattr(args, "cookies", None),
                 chrome_profile=getattr(args, "chrome_profile", None),
             )
-            logger.info("\n✓ Audio downloaded successfully!")
+            log_success("Downloaded audio")
 
         # Apply override if provided
         if video_info_override and video_info:
@@ -957,7 +955,7 @@ def process_input_source(
             if video_info_override.webpage_url:
                 video_info.webpage_url = video_info_override.webpage_url
 
-        logger.info(f"Title: {video_info.title}")
+        log_success(f"Title: {video_info.title}")
 
         # Create smart filename
         smart_filename = create_smart_filename(video_info.title, max_length=60, include_date=True)

--- a/tests/test_checkpoint_resume.py
+++ b/tests/test_checkpoint_resume.py
@@ -314,12 +314,36 @@ def test_reconstruct_args_restores_metadata_and_output_dir(checkpoint_dir, monke
     args = _reconstruct_args(m)
 
     # Input is redirected to the checkpoint's source.wav and duplicate detection is off.
-    assert args.input_source == str(m.source_wav_path)
+    assert args.input == str(m.source_wav_path)
     assert args.force is True
     assert args.resume_job_id == m.job_id
     # The original output dir survives (so resume writes to the intended location).
     assert args.output_dir == "/some/original/out"
     # The persisted model name is carried through for re-resolution.
+    assert args.whisper_model == "base.en"
+
+
+def test_reconstruct_args_drops_legacy_dead_flags(checkpoint_dir):
+    """Manifests from before the verb refactor may carry dropped dests.
+
+    ``analyze_existing``/``diarize_existing`` no longer exist on the transcribe
+    namespace; the overlay must filter them out rather than resurrecting them.
+    """
+    from pidcast.resume import _reconstruct_args
+
+    m = _make_manifest()
+    m.cli_args = {
+        "whisper_model": "base.en",
+        "analyze_existing": "/old/transcript.md",
+        "diarize_existing": "/old/other.md",
+    }
+    m.save()
+
+    args = _reconstruct_args(m)
+
+    assert not hasattr(args, "analyze_existing")
+    assert not hasattr(args, "diarize_existing")
+    # Live flags still overlay correctly.
     assert args.whisper_model == "base.en"
 
 

--- a/tests/test_cli_grammar.py
+++ b/tests/test_cli_grammar.py
@@ -1,0 +1,116 @@
+"""Tests for the verb-first CLI grammar introduced in the UX refactor.
+
+Pins the new public surface:
+  - ``parse_arguments(argv)`` accepts an explicit argv list (no sys.argv reliance).
+  - Every verb subparser sets ``args.command`` and ``args.func``.
+  - The bare-input shortcut injects ``transcribe`` per a precise rule
+    (``_inject_default_verb``): only when argv[0] is a non-empty token that is
+    not a known verb and does not start with ``-``.
+  - ``list <noun>`` parses the discovery nouns.
+"""
+
+import pytest
+
+from pidcast import cli
+
+# ---------------------------------------------------------------------------
+# Bare-input shortcut (_inject_default_verb)
+# ---------------------------------------------------------------------------
+
+
+def test_bare_url_injects_transcribe():
+    assert cli._inject_default_verb(["https://youtu.be/x"]) == [
+        "transcribe",
+        "https://youtu.be/x",
+    ]
+
+
+def test_bare_local_file_injects_transcribe():
+    # A filename that is not a known verb is treated as transcribe input.
+    assert cli._inject_default_verb(["episode.mp3"]) == ["transcribe", "episode.mp3"]
+
+
+def test_known_verb_is_not_reinjected():
+    assert cli._inject_default_verb(["transcribe", "x.mp3"]) == ["transcribe", "x.mp3"]
+    assert cli._inject_default_verb(["lib", "list"]) == ["lib", "list"]
+    assert cli._inject_default_verb(["analyze", "t.md"]) == ["analyze", "t.md"]
+
+
+def test_verb_name_shadows_filename():
+    # A file literally named like a verb is shadowed by the verb; documented
+    # behavior is to use `transcribe ./info` explicitly.
+    assert cli._inject_default_verb(["info"]) == ["info"]
+
+
+def test_flag_first_is_not_injected():
+    # argparse handles --help/-v on the root parser; never inject before a flag.
+    assert cli._inject_default_verb(["--help"]) == ["--help"]
+    assert cli._inject_default_verb(["-v"]) == ["-v"]
+
+
+def test_empty_argv_is_unchanged():
+    assert cli._inject_default_verb([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Verb dispatch: every verb parses and carries command + func
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("argv", "command"),
+    [
+        (["transcribe", "x.mp3"], "transcribe"),
+        (["analyze", "t.md"], "analyze"),
+        (["diarize", "t.md"], "diarize"),
+        (["setup"], "setup"),
+        (["doctor"], "doctor"),
+        (["resume"], "resume"),
+        (["info"], "info"),
+        (["list", "models"], "list"),
+        (["lib", "list"], "lib"),
+    ],
+)
+def test_verb_sets_command_and_func(argv, command):
+    args = cli.parse_arguments(argv)
+    assert args.command == command
+    assert callable(args.func)
+
+
+def test_transcribe_test_flag_maps_to_test_segment_dest():
+    # `--test` is the new spelling; internal dest stays test_segment.
+    args = cli.parse_arguments(["transcribe", "x.mp3", "--test", "5", "--start-at", "10"])
+    assert args.test_segment == 5
+    assert args.start_at == 10
+
+
+def test_analyze_takes_transcript_positional():
+    args = cli.parse_arguments(["analyze", "/path/to/t.md", "-a", "summary"])
+    assert args.transcript == "/path/to/t.md"
+    assert args.analysis_type == "summary"
+
+
+def test_diarize_takes_transcript_and_audio():
+    args = cli.parse_arguments(["diarize", "/path/to/t.md", "--audio", "/a.wav"])
+    assert args.transcript == "/path/to/t.md"
+    assert args.audio == "/a.wav"
+
+
+@pytest.mark.parametrize(
+    "noun",
+    ["analyses", "models", "whisper-models", "presets", "profiles"],
+)
+def test_list_nouns_parse(noun):
+    args = cli.parse_arguments(["list", noun])
+    assert args.command == "list"
+    assert args.thing == noun
+
+
+def test_build_transcribe_namespace_yields_transcribe_defaults():
+    # Resume relies on this to materialize a fully-defaulted transcribe Namespace.
+    ns = cli.build_transcribe_namespace("/job/source.wav")
+    assert ns.command == "transcribe"
+    assert ns.input == "/job/source.wav"
+    # A dest read as a bare attribute downstream must be present.
+    assert hasattr(ns, "no_analyze")
+    assert hasattr(ns, "save")

--- a/tests/test_duplicate_prompt.py
+++ b/tests/test_duplicate_prompt.py
@@ -1,0 +1,194 @@
+"""Tests for the redesigned duplicate-detection prompt.
+
+Detection logic lives in test_duplicate_detection.py; this file covers the new
+single-keypress selector (ui.select_key) and the panel/action mapping in
+duplicate.prompt_duplicate_detected.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from pidcast import ui
+from pidcast.duplicate import DuplicateAction, prompt_duplicate_detected
+
+CHOICES = [
+    ("r", "re-transcribe"),
+    ("a", "analyze"),
+    ("f", "force"),
+    ("c", "cancel"),
+]
+
+
+# ---------------------------------------------------------------------------
+# select_key — TTY path (monkeypatch the inner getch)
+# ---------------------------------------------------------------------------
+
+
+def _feed_keys(monkeypatch, keys):
+    """Make stdin a TTY and feed select_key one key per _read_raw_key() call."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True, raising=False)
+    seq = iter(keys)
+    monkeypatch.setattr(ui, "_read_raw_key", lambda: next(seq))
+
+
+def test_tty_keypress_matches_key(monkeypatch):
+    _feed_keys(monkeypatch, ["r"])
+    assert ui.select_key("", CHOICES, default="c") == "r"
+
+
+def test_tty_keypress_case_insensitive(monkeypatch):
+    _feed_keys(monkeypatch, ["R"])
+    assert ui.select_key("", CHOICES, default="c") == "r"
+
+
+def test_tty_enter_returns_default(monkeypatch):
+    _feed_keys(monkeypatch, ["\r"])
+    assert ui.select_key("", CHOICES, default="c") == "c"
+
+    _feed_keys(monkeypatch, ["\n"])
+    assert ui.select_key("", CHOICES, default="c") == "c"
+
+
+def test_tty_esc_returns_cancel(monkeypatch):
+    _feed_keys(monkeypatch, ["\x1b"])
+    assert ui.select_key("", CHOICES, default="r") == "c"
+
+
+def test_tty_ctrl_c_returns_cancel(monkeypatch):
+    _feed_keys(monkeypatch, ["\x03"])
+    assert ui.select_key("", CHOICES, default="r") == "c"
+
+
+def test_tty_eof_returns_cancel(monkeypatch):
+    _feed_keys(monkeypatch, [""])
+    assert ui.select_key("", CHOICES, default="r") == "c"
+
+
+def test_tty_invalid_key_rereads_until_valid(monkeypatch):
+    # 'x' and 'z' are not choices -> re-read; 'f' is -> returned.
+    _feed_keys(monkeypatch, ["x", "z", "f"])
+    assert ui.select_key("", CHOICES, default="c") == "f"
+
+
+def test_cancel_falls_back_to_default_when_no_cancel_choice(monkeypatch):
+    # No 'c' choice -> Esc resolves to the default key, not a missing cancel.
+    no_cancel = [("r", "re-transcribe"), ("f", "force")]
+    _feed_keys(monkeypatch, ["\x1b"])
+    assert ui.select_key("", no_cancel, default="r") == "r"
+
+
+# ---------------------------------------------------------------------------
+# select_key — non-TTY fallback path (input())
+# ---------------------------------------------------------------------------
+
+
+def test_non_tty_matches_first_char(monkeypatch):
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False, raising=False)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "a")
+    assert ui.select_key("hint", CHOICES, default="c") == "a"
+
+
+def test_non_tty_empty_line_returns_default(monkeypatch):
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False, raising=False)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "")
+    assert ui.select_key("hint", CHOICES, default="c") == "c"
+
+
+def test_non_tty_eof_returns_cancel(monkeypatch):
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False, raising=False)
+
+    def _raise(*a, **k):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _raise)
+    assert ui.select_key("hint", CHOICES, default="r") == "c"
+
+
+def test_non_tty_invalid_then_valid(monkeypatch):
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False, raising=False)
+    lines = iter(["nope", "f"])
+    monkeypatch.setattr("builtins.input", lambda *a, **k: next(lines))
+    assert ui.select_key("hint", CHOICES, default="c") == "f"
+
+
+# ---------------------------------------------------------------------------
+# prompt_duplicate_detected — key -> DuplicateAction mapping
+# ---------------------------------------------------------------------------
+
+
+class _FakePrev:
+    """Minimal stand-in for PreviousTranscription."""
+
+    def __init__(self, transcript_path: Path, *, analysis_performed=False, analysis_type=None):
+        self.video_title = "Some Episode Title"
+        self.formatted_date = "June 30, 2026 at 10:00"
+        self.analysis_performed = analysis_performed
+        self.analysis_type = analysis_type
+        self._transcript_path = transcript_path
+
+    @property
+    def transcript_path(self) -> Path:
+        return self._transcript_path
+
+
+@pytest.fixture
+def existing_transcript(tmp_path) -> Path:
+    p = tmp_path / "2026-06-30_Some_Episode.md"
+    p.write_text("# transcript\n")
+    return p
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("r", DuplicateAction.RE_TRANSCRIBE),
+        ("a", DuplicateAction.ANALYZE_EXISTING),
+        ("f", DuplicateAction.FORCE_CONTINUE),
+        ("c", DuplicateAction.CANCEL),
+    ],
+)
+def test_key_maps_to_action(monkeypatch, existing_transcript, key, expected):
+    prev = _FakePrev(existing_transcript)
+    monkeypatch.setattr(ui, "select_key", lambda *a, **k: key)
+    assert prompt_duplicate_detected(prev) is expected
+
+
+def test_analyze_choice_omitted_when_transcript_missing(monkeypatch, tmp_path):
+    prev = _FakePrev(tmp_path / "gone.md")  # never created -> does not exist
+
+    captured = {}
+
+    def _fake_select(prompt, choices, *, default):
+        captured["choices"] = choices
+        captured["default"] = default
+        return "c"
+
+    monkeypatch.setattr(ui, "select_key", _fake_select)
+
+    action = prompt_duplicate_detected(prev)
+    assert action is DuplicateAction.CANCEL
+
+    keys = [k for k, _ in captured["choices"]]
+    assert keys == ["r", "f", "c"]  # 'a' omitted
+    assert "a" not in keys
+    assert captured["default"] == "c"
+
+
+def test_analyze_choice_present_when_transcript_exists(monkeypatch, existing_transcript):
+    prev = _FakePrev(existing_transcript)
+
+    captured = {}
+
+    def _fake_select(prompt, choices, *, default):
+        captured["choices"] = choices
+        return "c"
+
+    monkeypatch.setattr(ui, "select_key", _fake_select)
+
+    prompt_duplicate_detected(prev)
+    keys = [k for k, _ in captured["choices"]]
+    assert keys == ["r", "a", "f", "c"]

--- a/tests/test_output_dir_resolution.py
+++ b/tests/test_output_dir_resolution.py
@@ -8,8 +8,7 @@ import argparse
 from pathlib import Path
 from unittest.mock import patch
 
-from pidcast.cli import resolve_output_dir
-from pidcast.config import TRANSCRIPTS_DIR
+from pidcast.config import TRANSCRIPTS_DIR, resolve_output_dir
 
 
 def _args(output_dir=None):

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from pidcast.cli import apply_preset
+from pidcast.cli import _explicitly_set_dests, apply_preset
 from pidcast.config_manager import ConfigManager
 
 
@@ -158,3 +158,35 @@ class TestApplyPreset:
         ):
             apply_preset(args)
         assert "Unknown preset key 'bogus_flag'" in caplog.text
+
+
+class TestExplicitlySetDetection:
+    """Detecting which dests the user passed, regardless of flag spelling.
+
+    Replaces a brittle sys.argv substring scan that missed short aliases and
+    BooleanOptionalAction, letting a preset wrongly clobber a flag the user set.
+    """
+
+    def test_long_flag_detected(self):
+        dests = _explicitly_set_dests(["transcribe", "x.mp3", "--groq-model", "llama33"])
+        assert "groq_model" in dests
+
+    def test_short_alias_detected(self):
+        # The old scan missed `-m` (only matched --groq-model).
+        dests = _explicitly_set_dests(["transcribe", "x.mp3", "-m", "llama33"])
+        assert "groq_model" in dests
+
+    def test_boolean_optional_action_detected(self):
+        # The old scan missed `--no-suppress-nst` (dest is suppress_nst).
+        dests = _explicitly_set_dests(["transcribe", "x.mp3", "--no-suppress-nst"])
+        assert "suppress_nst" in dests
+
+    def test_unset_flag_not_detected(self):
+        dests = _explicitly_set_dests(["transcribe", "x.mp3"])
+        assert "groq_model" not in dests
+        assert "language" not in dests
+
+    def test_preset_flag_itself_not_reported_as_clobberable(self):
+        dests = _explicitly_set_dests(["transcribe", "x.mp3", "-p", "daily"])
+        # `input` is positional and present, but a preset can't target it anyway.
+        assert "groq_model" not in dests

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,79 @@
+"""Tests for the single-owner run reporter (ui.RunReporter).
+
+The reporter owns ONE rich Console/Live/Progress for a run so progress never
+gets "pushed down" by interleaved prints. In a non-TTY environment (pipes,
+pytest) it must degrade to plain logging and never start a Live region.
+"""
+
+import logging
+
+from pidcast import ui
+
+
+def test_active_reporter_is_none_by_default():
+    assert ui.active_reporter() is None
+
+
+def test_reporter_registers_and_clears_itself_as_active():
+    reporter = ui.RunReporter(verbose=False)
+    assert ui.active_reporter() is None
+    with reporter:
+        assert ui.active_reporter() is reporter
+    # Cleared on exit, even though we never started a Live (non-TTY).
+    assert ui.active_reporter() is None
+
+
+def test_reporter_clears_active_on_exception():
+    reporter = ui.RunReporter(verbose=False)
+    try:
+        with reporter:
+            assert ui.active_reporter() is reporter
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert ui.active_reporter() is None
+
+
+def test_non_tty_does_not_start_live():
+    # Under pytest stdout is not a TTY, so no Live should be created.
+    reporter = ui.RunReporter(verbose=False)
+    with reporter:
+        assert reporter.is_live is False
+
+
+def test_task_handle_updates_are_safe_without_live(caplog):
+    # A task handle must be a no-op-safe object when there's no Live region,
+    # so producers can always call task.update() unconditionally.
+    reporter = ui.RunReporter(verbose=False)
+    with reporter:
+        task = reporter.task("Transcribing", total=1000)
+        task.update(completed=500)
+        task.update(completed=1000)
+    # No exception == pass.
+
+
+def test_log_emits_without_live(caplog):
+    reporter = ui.RunReporter(verbose=False)
+    with caplog.at_level(logging.INFO), reporter:
+        reporter.log("downloaded 42 MB")
+    assert "downloaded 42 MB" in caplog.text
+
+
+def test_error_emits_without_live(caplog):
+    reporter = ui.RunReporter(verbose=False)
+    with caplog.at_level(logging.ERROR), reporter:
+        reporter.error("it broke")
+    assert "it broke" in caplog.text
+
+
+def test_nested_reporter_does_not_clobber_outer_active():
+    # A second reporter entering while one is active must restore the previous
+    # active reporter on exit (so lib sync's per-episode reporters nest safely).
+    outer = ui.RunReporter(verbose=False)
+    inner = ui.RunReporter(verbose=False)
+    with outer:
+        assert ui.active_reporter() is outer
+        with inner:
+            assert ui.active_reporter() is inner
+        assert ui.active_reporter() is outer
+    assert ui.active_reporter() is None


### PR DESCRIPTION
## Summary
- Reworks the CLI into a verb-first grammar: `pidcast transcribe|analyze|diarize|list|info|lib`, with bare `pidcast <url|file>` still shortcutting to `transcribe`. Discovery flags (`-L/-M/-W/-P`, `--list-chrome-profiles`) collapse under `pidcast list <…>`; `pidcast paths` becomes `pidcast info`.
- Replaces three competing output systems with one owned rich `Live` display per run, so the progress bar updates in place and never gets "pushed down" by interleaved logging; piped/CI output degrades cleanly to plain logging.
- Redesigns the duplicate-detection prompt into one compact rounded panel with instant single-keypress selection (`r`/`a`/`f`/`c`), replacing the old "type a number then Enter" menu.
- Fixes preset merging silently clobbering explicitly-passed short flags and `--no-*` booleans.

## Why
The CLI had grown into a ~2000-line monolith mixing several dispatch mechanisms, a cryptic single-letter discovery surface, and three independent output paths that fought each other on screen. Users saw the progress bar redrawn under summaries, duplicated status lines, and a dated numbered prompt; presets could quietly override a flag you'd just typed. This overhaul makes the command surface predictable, the run output stable and modern, and preset behavior correct.

**Breaking:** the command grammar changed with no compat shims. `--analyze-existing`/`--diarize-existing` are now the `analyze`/`diarize` verbs, `--test-segment` is `--test` on `transcribe`, and the `-L/-M/-W/-P` discovery flags are gone in favor of `pidcast list`. Expert whisper-tuning flags are hidden from `--help` (still settable via config/presets).

## Changes
- **Phase 1 — grammar:** `cli.py` drops 2014 → 609 lines; handler bodies move verbatim into a new `commands/` package. `resolve_output_dir`/legacy-path helpers move to `config.py`; `resume.py` rebuilds its namespace via `build_transcribe_namespace()` instead of mutating `sys.argv`.
- **Phase 3 — run UI:** new `ui.py` with `RunReporter` (context manager) + `active_reporter()` + a safe `_TaskHandle`. whisper streaming and analysis chunking drive the shared task when a reporter is live; `log_*` delegate to it. Whisper stdout is always captured (even in `--verbose`) and rendered dimmed above the bar.
- **Phase 4 — duplicate prompt:** rewritten `prompt_duplicate_detected` panel + reusable `ui.select_key` single-keypress helper with a non-TTY `input()` fallback; removes the numbered menu and `_prompt_duplicate_basic`. `DuplicateAction` contract unchanged, so transcribe dispatch is untouched. `analyze` choice is offered only when the transcript file still exists.
- **Preset fix:** explicit-flag detection re-parses argv through a shadow parser whose defaults are all `SUPPRESS`, so short aliases (`-m`) and `--no-*` booleans are correctly preserved over presets.
- Docs synced to the verb-first surface (README, CLAUDE.md, architecture, dev-guide). Version bumped 0.14.1 → 0.17.0 across the branch.

## Test plan
- [x] `uv run pytest` — 469 passed, 2 skipped
- [x] `uv run ruff check src/ tests/` clean; format clean
- [x] Duplicate prompt: panel renders; `a`→analyze, empty→cancel, `a`-when-unavailable re-reads then `f`→force; non-TTY fallback engages without raw-mode artifacts
- [ ] Real-terminal smoke: trigger a duplicate, confirm a single keypress acts instantly (no Enter)
- [ ] Smoke a full `pidcast transcribe <url>` run and confirm the bar stays in place and clears on completion