### PR TITLE
History command, Groq JSON-mode fix, and Claude model ID refresh

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -2,7 +2,7 @@
 # Quality-prioritized fallback chain for LLM analysis
 
 # Last time pricing data was verified against provider pricing pages
-pricing_last_updated: "2026-03-06"
+pricing_last_updated: "2026-07-01"
 
 # Default model to use (best quality)
 default_model: openai/gpt-oss-120b
@@ -97,10 +97,10 @@ models:
       tpd: 1000000
 
   # Claude models (used via CLI pipe, not in Groq fallback chain)
-  claude-sonnet-4-6:
-    display_name: Claude Sonnet 4.6
+  claude-sonnet-5:
+    display_name: Claude Sonnet 5
     provider: claude
-    context_window: 200000
+    context_window: 1000000
     pricing:
       input: 3.00
       output: 15.00
@@ -110,13 +110,13 @@ models:
       tpm: 0
       tpd: 0
 
-  claude-opus-4-6:
-    display_name: Claude Opus 4.6
+  claude-opus-4-8:
+    display_name: Claude Opus 4.8
     provider: claude
-    context_window: 200000
+    context_window: 1000000
     pricing:
-      input: 15.00
-      output: 75.00
+      input: 5.00
+      output: 25.00
     limits:
       rpm: 0
       rpd: 0
@@ -128,8 +128,8 @@ models:
     provider: claude
     context_window: 200000
     pricing:
-      input: 0.80
-      output: 4.00
+      input: 1.00
+      output: 5.00
     limits:
       rpm: 0
       rpd: 0

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -9,9 +9,14 @@ default_model: openai/gpt-oss-120b
 
 # Quality-prioritized fallback chain (best to acceptable)
 # When a model hits rate limits, try the next one in the chain
+#
+# groq/compound is deliberately excluded: it's an agentic/tool-use model with
+# its own hidden per-request payload ceiling independent of its advertised
+# context window/TPM, so it reliably 413s on JSON-mode summarization requests
+# that are nowhere near its token limits. Still selectable explicitly via
+# --groq-model compound; just not part of the automatic fallback sequence.
 fallback_chain:
   - openai/gpt-oss-120b
-  - groq/compound
   - openai/gpt-oss-20b
   - llama-3.3-70b-versatile
   - llama-3.1-8b-instant
@@ -22,6 +27,9 @@ models:
     display_name: GPT-OSS 120B
     provider: groq
     context_window: 131072
+    # Confirmed live (2026-07) against Groq's strict json_schema structured
+    # outputs mode - verify live if Groq's supported-model list changes.
+    supports_json_schema: true
     pricing:
       input: 0.15   # per 1M tokens
       output: 0.60
@@ -48,6 +56,9 @@ models:
     display_name: GPT-OSS 20B
     provider: groq
     context_window: 131072
+    # Confirmed live (2026-07) against Groq's strict json_schema structured
+    # outputs mode - verify live if Groq's supported-model list changes.
+    supports_json_schema: true
     pricing:
       input: 0.075
       output: 0.30

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pidcast"
-version = "0.17.0"
+version = "0.17.1"
 description = "YouTube transcription tool with Whisper and LLM analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/pidcast/analysis.py
+++ b/src/pidcast/analysis.py
@@ -184,7 +184,31 @@ JSON_VALIDATION_ERROR_PATTERNS = [
     "Expected JSON",
     "json.decoder.JSONDecodeError",
     "json_schema_error",
+    "invalid json schema for response_format",
 ]
+
+
+# Shared output shape for executive_summary/summary/key_points/action_items/
+# comprehensive/synthesis prompts. Used with Groq's strict json_schema mode
+# on models with confirmed support (see ModelConfig.supports_json_schema).
+ANALYSIS_JSON_SCHEMA = {
+    "name": "transcript_analysis",
+    "schema": {
+        "type": "object",
+        "properties": {
+            "analysis": {"type": "string"},
+            "contextual_tags": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 3,
+                "maxItems": 3,
+            },
+        },
+        "required": ["analysis", "contextual_tags"],
+        "additionalProperties": False,
+    },
+    "strict": True,
+}
 
 
 def is_json_validation_error(error: Exception) -> bool:
@@ -411,7 +435,14 @@ def _call_llm_with_fallback(
             "timeout": ANALYSIS_TIMEOUT,
         }
         if use_json_mode:
-            kwargs["response_format"] = {"type": "json_object"}
+            model_config = selector.get_model_config(model_name)
+            if model_config and model_config.supports_json_schema:
+                kwargs["response_format"] = {
+                    "type": "json_schema",
+                    "json_schema": ANALYSIS_JSON_SCHEMA,
+                }
+            else:
+                kwargs["response_format"] = {"type": "json_object"}
         return client.chat.completions.create(**kwargs)
 
     current_model = preferred_model
@@ -455,6 +486,8 @@ def _call_llm_with_fallback(
 
                 # Try next model in fallback chain for JSON issues
                 log_warning(f"{selector.get_display_name(current_model)} failed JSON validation")
+                if verbose:
+                    logger.info(f"  Groq error detail: {e}")
                 # Mark this model as tried and get next fallback
                 selector.mark_tried(current_model)
                 next_model = selector.get_next_fallback()
@@ -504,10 +537,21 @@ def _call_llm_with_fallback(
                             f"  3. Check if your transcript is extremely short (models need enough content)"
                         ) from e
             elif is_payload_too_large_error(e):
+                from .utils import log_error_to_file
+
                 log_warning(
                     f"{selector.get_display_name(current_model)} rejected payload as too large"
                 )
-                next_model = selector.handle_rate_limit(current_model)
+                if verbose:
+                    logger.info(f"  Groq error detail: {e}")
+                log_error_to_file(
+                    "payload_too_large_error",
+                    {
+                        "model": current_model,
+                        "error_message": str(e),
+                    },
+                )
+                next_model = selector.handle_rate_limit(current_model, reason="Payload too large")
                 if next_model:
                     current_model = next_model
                     continue

--- a/src/pidcast/cli.py
+++ b/src/pidcast/cli.py
@@ -37,6 +37,7 @@ KNOWN_VERBS = frozenset(
         "doctor",
         "resume",
         "info",
+        "history",
     }
 )
 
@@ -375,6 +376,7 @@ def _build_parser() -> argparse.ArgumentParser:
     """Construct the full verb-first parser (unconditional subparser tree)."""
     from .commands.analyze import cmd_analyze
     from .commands.diarize import cmd_diarize
+    from .commands.history import cmd_history
     from .commands.info import cmd_info
     from .commands.listing import cmd_list
     from .commands.transcribe import cmd_transcribe
@@ -396,6 +398,7 @@ Common workflows:
   pidcast diarize transcript.md                     Retry diarization only
   pidcast list models                               Discover analyses/models/presets/...
   pidcast lib add "Lex Fridman"                     Manage the podcast library
+  pidcast history -n 20                             Show last 20 runs
 """,
     )
     sub = parser.add_subparsers(dest="command", metavar="<command>")
@@ -507,6 +510,14 @@ Common workflows:
         "info", parents=[parents["global"]], help="Show resolved data/config paths"
     )
     inf.set_defaults(func=cmd_info)
+
+    hi = sub.add_parser(
+        "history", parents=[parents["global"]], help="List recent transcription runs"
+    )
+    hi.add_argument(
+        "-n", "--limit", type=int, default=10, help="Number of runs to show (default: 10)"
+    )
+    hi.set_defaults(func=cmd_history)
 
     return parser
 

--- a/src/pidcast/commands/history.py
+++ b/src/pidcast/commands/history.py
@@ -1,0 +1,108 @@
+"""Handler for ``pidcast history`` — list the last N recorded runs.
+
+Run dicts in the unified store are not uniformly shaped: legacy/pre-migration
+entries can be as sparse as 5 keys. Every field below is read defensively;
+only ``run_timestamp`` is guaranteed present on every entry.
+"""
+
+import argparse
+import logging
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_TITLE_WIDTH = 50
+
+
+def cmd_history(args: argparse.Namespace) -> None:
+    """Print the last ``args.limit`` recorded runs, newest first."""
+    from ..config import RUNS_FILE
+    from ..history import RunHistory
+
+    runs = RunHistory(RUNS_FILE).get_runs_for_estimation()
+    if not runs:
+        print("No run history yet. Transcribe something to get started.")
+        return
+
+    runs = sorted(runs, key=lambda r: r.get("run_timestamp") or "", reverse=True)
+    runs = runs[: args.limit]
+
+    try:
+        from rich.console import Console
+        from rich.table import Table
+
+        has_rich = True
+    except ImportError:
+        has_rich = False
+
+    if has_rich:
+        console = Console()
+        table = Table(show_header=True, title=f"Run History (last {len(runs)})")
+        table.add_column("Date", style="dim", width=16, no_wrap=True)
+        table.add_column("Title", style="white", width=_TITLE_WIDTH, no_wrap=True)
+        table.add_column("Provider", style="cyan", width=10, no_wrap=True)
+        table.add_column("Duration", style="yellow", justify="right", width=10, no_wrap=True)
+        table.add_column("Status", justify="center", width=6, no_wrap=True)
+        table.add_column("Transcript", style="green", width=20, no_wrap=True)
+
+        for entry in runs:
+            table.add_row(*_row(entry))
+        console.print(table)
+    else:
+        print(f"\nRun History (last {len(runs)}):")
+        print("-" * 100)
+        for entry in runs:
+            date, title, provider, duration, status, transcript = _row(entry)
+            print(f"{date}  [{status}]  {title}")
+            print(f"    provider: {provider}  duration: {duration}  transcript: {transcript}")
+
+
+def _row(entry: dict) -> tuple[str, str, str, str, str, str]:
+    """Format one run dict into display columns, tolerating sparse entries."""
+    return (
+        _format_date(entry.get("run_timestamp")),
+        _format_title(entry.get("video_title")),
+        entry.get("transcription_provider") or "-",
+        _format_duration(entry.get("audio_duration")),
+        _format_status(entry.get("success")),
+        _format_transcript(entry.get("transcript_path")),
+    )
+
+
+def _format_date(raw: str | None) -> str:
+    if not raw:
+        return "-"
+    try:
+        return datetime.fromisoformat(raw).strftime("%Y-%m-%d %H:%M")
+    except ValueError:
+        return raw
+
+
+def _format_title(title: str | None) -> str:
+    title = title or "(untitled)"
+    if len(title) > _TITLE_WIDTH:
+        return title[: _TITLE_WIDTH - 1] + "…"
+    return title
+
+
+def _format_duration(seconds: float | None) -> str:
+    if seconds is None:
+        return "-"
+    from ..utils import format_duration
+
+    return format_duration(seconds)
+
+
+def _format_status(success: bool | None) -> str:
+    if success is True:
+        return "✓"
+    if success is False:
+        return "✗"
+    return "?"
+
+
+def _format_transcript(transcript_path: str | None) -> str:
+    if not transcript_path:
+        return "-"
+    return Path(transcript_path).name

--- a/src/pidcast/model_selector.py
+++ b/src/pidcast/model_selector.py
@@ -36,6 +36,7 @@ class ModelConfig:
     rpd: int
     tpm: int
     tpd: int
+    supports_json_schema: bool = False
 
     def estimate_cost(self, input_tokens: int, output_tokens: int) -> float:
         """Estimate cost for given token counts."""
@@ -106,6 +107,7 @@ def load_models_config(config_path: Path) -> ModelsConfig:
             rpd=limits.get("rpd", 1000),
             tpm=limits.get("tpm", 10000),
             tpd=limits.get("tpd", 0),
+            supports_json_schema=cfg.get("supports_json_schema", False),
         )
 
     default_model = data.get("default_model", "llama-3.3-70b-versatile")
@@ -407,11 +409,18 @@ class ModelSelector:
         )
         return None, False
 
-    def handle_rate_limit(self, current_model: str) -> str | None:
-        """Handle a rate limit error by selecting next fallback.
+    def handle_rate_limit(self, current_model: str, reason: str = "Rate limit") -> str | None:
+        """Advance to the next fallback model after a failure.
+
+        Despite the name (kept for the common rate-limit case), this is used
+        for any error that should advance the fallback chain — callers pass a
+        ``reason`` describing the actual failure (e.g. "Payload too large")
+        so the log reflects what really happened instead of always saying
+        "Rate limit".
 
         Args:
-            current_model: The model that hit the rate limit
+            current_model: The model that failed
+            reason: Short description of why this model was skipped
 
         Returns:
             Next model to try, or None if all exhausted
@@ -420,11 +429,11 @@ class ModelSelector:
         next_model = self.get_next_fallback()
 
         if next_model:
-            logger.info(f"Rate limit on {current_model}, falling back to {next_model}")
+            logger.info(f"{reason} on {current_model}, falling back to {next_model}")
             return next_model
 
         logger.error(
-            f"Rate limit on {current_model} and no more fallback models. "
+            f"{reason} on {current_model} and no more fallback models. "
             f"Tried: {', '.join(sorted(self._tried_models))}"
         )
         return None

--- a/src/pidcast/providers/claude_provider.py
+++ b/src/pidcast/providers/claude_provider.py
@@ -21,8 +21,8 @@ logger = logging.getLogger(__name__)
 
 # Claude models available via CLI
 CLAUDE_MODELS = {
-    "sonnet": "claude-sonnet-4-6",
-    "opus": "claude-opus-4-6",
+    "sonnet": "claude-sonnet-5",
+    "opus": "claude-opus-4-8",
     "haiku": "claude-haiku-4-5-20251001",
 }
 DEFAULT_CLAUDE_MODEL = "sonnet"

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,171 @@
+"""Tests for pidcast.analysis's Groq JSON-mode request building.
+
+Covers the fix for GPT-OSS 120B/20B frequently failing Groq's loose
+`json_object` JSON validation (HTTP 400, json_validate_failed) by using
+Groq's strict `json_schema` structured-outputs mode on models with confirmed
+support (ModelConfig.supports_json_schema), while models without that support
+keep the existing json_object mode.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+from pidcast.analysis import ANALYSIS_JSON_SCHEMA, _call_llm_with_fallback
+from pidcast.model_selector import ModelConfig, ModelsConfig, ModelSelector
+
+
+def _make_model(name: str, supports_json_schema: bool) -> ModelConfig:
+    return ModelConfig(
+        name=name,
+        display_name=name,
+        provider="groq",
+        context_window=131072,
+        pricing_input=0.1,
+        pricing_output=0.1,
+        rpm=30,
+        rpd=1000,
+        tpm=8000,
+        tpd=200000,
+        supports_json_schema=supports_json_schema,
+    )
+
+
+def _schema_and_object_config() -> ModelsConfig:
+    schema_model = _make_model("schema-model", supports_json_schema=True)
+    object_model = _make_model("object-model", supports_json_schema=False)
+    return ModelsConfig(
+        default_model="schema-model",
+        fallback_chain=["schema-model", "object-model"],
+        models={"schema-model": schema_model, "object-model": object_model},
+    )
+
+
+def _fake_groq_response(analysis: str = "some analysis", tags: list | None = None):
+    """A response object shaped like the real Groq SDK's return value.
+
+    Only a bare Mock() would let LLMCallResult's int fields (tokens_in/out/
+    total) through as Mock objects without failing a broken assertion, so
+    every field _call_llm_with_fallback actually reads is set explicitly.
+    """
+    tags = tags if tags is not None else ["tag-one", "tag-two", "tag-three"]
+    content = json.dumps({"analysis": analysis, "contextual_tags": tags})
+
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = content
+    response.usage.prompt_tokens = 100
+    response.usage.completion_tokens = 50
+    response.usage.total_tokens = 150
+    return response
+
+
+class TestAnalysisJsonSchema:
+    def test_schema_has_additional_properties_false_and_matches_required(self):
+        schema = ANALYSIS_JSON_SCHEMA["schema"]
+        assert schema["additionalProperties"] is False
+        assert set(schema["required"]) == set(schema["properties"].keys())
+        assert ANALYSIS_JSON_SCHEMA["strict"] is True
+
+    def test_contextual_tags_requires_exactly_three(self):
+        tags_schema = ANALYSIS_JSON_SCHEMA["schema"]["properties"]["contextual_tags"]
+        assert tags_schema["minItems"] == 3
+        assert tags_schema["maxItems"] == 3
+
+
+class TestCallLlmWithFallbackRequestFormat:
+    def test_schema_capable_model_uses_json_schema_mode(self):
+        config = _schema_and_object_config()
+        selector = ModelSelector(config)
+        client = MagicMock()
+        client.chat.completions.create.return_value = _fake_groq_response()
+
+        _call_llm_with_fallback(
+            client,
+            selector,
+            system_prompt="system",
+            user_prompt="user",
+            max_tokens=500,
+            preferred_model="schema-model",
+            use_json_mode=True,
+        )
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["response_format"] == {
+            "type": "json_schema",
+            "json_schema": ANALYSIS_JSON_SCHEMA,
+        }
+
+    def test_non_schema_capable_model_keeps_json_object_mode(self):
+        config = _schema_and_object_config()
+        selector = ModelSelector(config)
+        client = MagicMock()
+        client.chat.completions.create.return_value = _fake_groq_response()
+
+        _call_llm_with_fallback(
+            client,
+            selector,
+            system_prompt="system",
+            user_prompt="user",
+            max_tokens=500,
+            preferred_model="object-model",
+            use_json_mode=True,
+        )
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["response_format"] == {"type": "json_object"}
+
+    def test_json_mode_false_sends_no_response_format(self):
+        config = _schema_and_object_config()
+        selector = ModelSelector(config)
+        client = MagicMock()
+        client.chat.completions.create.return_value = _fake_groq_response()
+
+        _call_llm_with_fallback(
+            client,
+            selector,
+            system_prompt="system",
+            user_prompt="user",
+            max_tokens=500,
+            preferred_model="schema-model",
+            use_json_mode=False,
+        )
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert "response_format" not in kwargs
+
+
+class TestJsonValidationFallbackTransition:
+    def test_schema_model_json_validate_failure_falls_back_to_json_object_model(self):
+        """A json_validate_failed error on the schema-capable model must
+        advance to the next model in the chain, which then uses json_object
+        mode (not the schema) - the real failure-recovery path being fixed."""
+        config = _schema_and_object_config()
+        selector = ModelSelector(config)
+        client = MagicMock()
+
+        json_validation_error = Exception(
+            "Error code: 400 - {'error': {'message': \"Failed to validate JSON. "
+            "Please adjust your prompt.\", 'code': 'json_validate_failed'}}"
+        )
+        client.chat.completions.create.side_effect = [
+            json_validation_error,
+            _fake_groq_response(),
+        ]
+
+        result = _call_llm_with_fallback(
+            client,
+            selector,
+            system_prompt="system",
+            user_prompt="user",
+            max_tokens=500,
+            preferred_model="schema-model",
+            use_json_mode=True,
+        )
+
+        assert result.model == "object-model"
+        assert client.chat.completions.create.call_count == 2
+
+        first_call_kwargs = client.chat.completions.create.call_args_list[0].kwargs
+        second_call_kwargs = client.chat.completions.create.call_args_list[1].kwargs
+        assert first_call_kwargs["response_format"]["type"] == "json_schema"
+        assert second_call_kwargs["response_format"] == {"type": "json_object"}

--- a/tests/test_claude_provider.py
+++ b/tests/test_claude_provider.py
@@ -107,7 +107,7 @@ class TestRunClaudeSubprocess:
             patch("pidcast.providers.claude_provider._find_claude_cli", return_value="/bin/claude"),
             patch("subprocess.run", return_value=self._mock_proc(stdout="  hello  ")),
         ):
-            result = run_claude_subprocess("prompt", "claude-sonnet-4-6")
+            result = run_claude_subprocess("prompt", "claude-sonnet-5")
         assert result == "hello"
 
     def test_raises_on_nonzero_exit(self):
@@ -118,7 +118,7 @@ class TestRunClaudeSubprocess:
             ),
             pytest.raises(AnalysisError, match="exited with code 1"),
         ):
-            run_claude_subprocess("prompt", "claude-sonnet-4-6")
+            run_claude_subprocess("prompt", "claude-sonnet-5")
 
     def test_raises_on_empty_output(self):
         with (
@@ -126,7 +126,7 @@ class TestRunClaudeSubprocess:
             patch("subprocess.run", return_value=self._mock_proc(stdout="")),
             pytest.raises(AnalysisError, match="empty output"),
         ):
-            run_claude_subprocess("prompt", "claude-sonnet-4-6")
+            run_claude_subprocess("prompt", "claude-sonnet-5")
 
     def test_raises_on_timeout(self):
         with (
@@ -136,7 +136,7 @@ class TestRunClaudeSubprocess:
             ),
             pytest.raises(AnalysisError, match="timed out"),
         ):
-            run_claude_subprocess("prompt", "claude-sonnet-4-6")
+            run_claude_subprocess("prompt", "claude-sonnet-5")
 
     def test_raises_on_os_error(self):
         with (
@@ -144,7 +144,7 @@ class TestRunClaudeSubprocess:
             patch("subprocess.run", side_effect=OSError("no such file")),
             pytest.raises(AnalysisError, match="Failed to invoke"),
         ):
-            run_claude_subprocess("prompt", "claude-sonnet-4-6")
+            run_claude_subprocess("prompt", "claude-sonnet-5")
 
 
 # ============================================================================

--- a/tests/test_cli_grammar.py
+++ b/tests/test_cli_grammar.py
@@ -69,6 +69,7 @@ def test_empty_argv_is_unchanged():
         (["info"], "info"),
         (["list", "models"], "list"),
         (["lib", "list"], "lib"),
+        (["history"], "history"),
     ],
 )
 def test_verb_sets_command_and_func(argv, command):

--- a/tests/test_history_command.py
+++ b/tests/test_history_command.py
@@ -1,0 +1,127 @@
+"""Unit tests for ``pidcast history`` rendering.
+
+Run dicts in the unified store are not uniformly shaped (legacy/pre-migration
+entries can be as sparse as 5 keys), so these tests assert the command
+tolerates missing fields instead of crashing on real, already-existing data.
+"""
+
+import argparse
+
+import pytest
+
+from pidcast.commands.history import _format_date, _format_status, _row, cmd_history
+
+FULL_ENTRY = {
+    "run_uid": "uid-1",
+    "run_timestamp": "2026-06-30T10:00:00",
+    "video_title": "A Full Episode",
+    "video_url": "https://youtube.com/watch?v=abc123",
+    "run_duration": 12.0,
+    "transcription_duration": 8.0,
+    "audio_duration": 3000.0,
+    "success": True,
+    "transcript_path": "/data/transcripts/2026-06-30_A_Full_Episode.md",
+    "transcription_provider": "whisper",
+}
+
+SPARSE_LEGACY_ENTRY = {
+    "run_uid": "uid-2",
+    "run_timestamp": "2025-01-15T09:00:00",
+    "video_title": "Legacy Episode",
+    "video_url": "https://youtube.com/watch?v=legacy",
+    "run_duration": 5.0,
+}
+
+FAILED_ENTRY = {
+    "run_uid": "uid-3",
+    "run_timestamp": "2026-07-01T08:00:00",
+    "video_title": "Broken Episode",
+    "video_url": "https://youtube.com/watch?v=broken",
+    "run_duration": 1.0,
+    "success": False,
+    "transcript_path": None,
+    "transcription_provider": "whisper",
+}
+
+
+def test_row_full_entry_formats_all_columns():
+    date, title, provider, duration, status, transcript = _row(FULL_ENTRY)
+    assert date == "2026-06-30 10:00"
+    assert title == "A Full Episode"
+    assert provider == "whisper"
+    assert duration == "50m 0s"
+    assert status == "✓"
+    assert transcript == "2026-06-30_A_Full_Episode.md"
+
+
+def test_row_sparse_legacy_entry_does_not_raise():
+    date, title, provider, duration, status, transcript = _row(SPARSE_LEGACY_ENTRY)
+    assert date == "2025-01-15 09:00"
+    assert title == "Legacy Episode"
+    assert provider == "-"
+    assert duration == "-"
+    assert status == "?"
+    assert transcript == "-"
+
+
+def test_row_failed_entry_does_not_raise_on_none_transcript_path():
+    date, title, provider, duration, status, transcript = _row(FAILED_ENTRY)
+    assert status == "✗"
+    assert transcript == "-"
+
+
+def test_format_status_tri_state():
+    assert _format_status(True) == "✓"
+    assert _format_status(False) == "✗"
+    assert _format_status(None) == "?"
+
+
+def test_format_date_falls_back_on_bad_timestamp():
+    assert _format_date("not-a-timestamp") == "not-a-timestamp"
+    assert _format_date(None) == "-"
+
+
+@pytest.fixture
+def runs_file(tmp_path):
+    import json
+
+    path = tmp_path / "runs.json"
+    data = {"by_guid": {}, "runs": [SPARSE_LEGACY_ENTRY, FULL_ENTRY, FAILED_ENTRY]}
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_cmd_history_handles_mixed_shapes_without_raising(runs_file, monkeypatch, capsys):
+    monkeypatch.setattr("pidcast.config.RUNS_FILE", runs_file)
+    args = argparse.Namespace(limit=10)
+
+    cmd_history(args)
+
+    # Rich wraps long titles across lines, so assert on unwrapped substrings.
+    out = capsys.readouterr().out.replace("\n", "")
+    assert "Full" in out and "Episode" in out
+    assert "Legacy" in out
+    assert "Broken" in out
+
+
+def test_cmd_history_respects_limit_and_orders_newest_first(runs_file, monkeypatch, capsys):
+    monkeypatch.setattr("pidcast.config.RUNS_FILE", runs_file)
+    args = argparse.Namespace(limit=1)
+
+    cmd_history(args)
+
+    out = capsys.readouterr().out.replace("\n", "")
+    assert "Broken" in out
+    assert "Full" not in out
+    assert "Legacy" not in out
+
+
+def test_cmd_history_empty_store(tmp_path, monkeypatch, capsys):
+    empty_path = tmp_path / "empty_runs.json"
+    monkeypatch.setattr("pidcast.config.RUNS_FILE", empty_path)
+    args = argparse.Namespace(limit=10)
+
+    cmd_history(args)
+
+    out = capsys.readouterr().out
+    assert "No run history yet" in out

--- a/tests/test_model_selector.py
+++ b/tests/test_model_selector.py
@@ -287,6 +287,22 @@ class TestModelSelector:
         result = selector.handle_rate_limit("small-model")
         assert result is None
 
+    def test_handle_rate_limit_reason_reflected_in_log(self, sample_models_config, caplog):
+        """A non-rate-limit failure (e.g. 413 payload too large) must not be
+        mislabeled as 'Rate limit' in the log — the caller-supplied reason
+        should appear verbatim."""
+        selector = ModelSelector(sample_models_config)
+        with caplog.at_level("INFO"):
+            selector.handle_rate_limit("large-model", reason="Payload too large")
+        assert "Payload too large on large-model" in caplog.text
+        assert "Rate limit on large-model" not in caplog.text
+
+    def test_handle_rate_limit_default_reason_is_rate_limit(self, sample_models_config, caplog):
+        selector = ModelSelector(sample_models_config)
+        with caplog.at_level("INFO"):
+            selector.handle_rate_limit("large-model")
+        assert "Rate limit on large-model" in caplog.text
+
     def test_reset(self, sample_models_config):
         selector = ModelSelector(sample_models_config)
         selector.mark_tried("large-model")

--- a/tests/test_provider_comparison.py
+++ b/tests/test_provider_comparison.py
@@ -53,7 +53,7 @@ def _make_comparison_result(**kwargs) -> ComparisonResult:
         "score_b": ProviderScore(accuracy=9, completeness=8, clarity=8, conciseness=7),
         "verdict": "B",
         "reasoning": "B was more accurate.",
-        "judge_model": "claude-opus-4-6",
+        "judge_model": "claude-opus-4-8",
         "duration_total": 15.0,
     }
     defaults.update(kwargs)
@@ -132,7 +132,7 @@ class TestJudgeSummaries:
             return_value=self.JUDGE_JSON,
         ):
             score_a, score_b, verdict, reasoning = _judge_summaries(
-                "Summary A", "Summary B", title="Episode", judge_model="claude-opus-4-6"
+                "Summary A", "Summary B", title="Episode", judge_model="claude-opus-4-8"
             )
 
         assert score_a.accuracy == 8
@@ -147,7 +147,7 @@ class TestJudgeSummaries:
             return_value=wrapped,
         ):
             score_a, score_b, verdict, _ = _judge_summaries(
-                "A", "B", title="Ep", judge_model="claude-opus-4-6"
+                "A", "B", title="Ep", judge_model="claude-opus-4-8"
             )
 
         assert score_a.accuracy == 8
@@ -161,7 +161,7 @@ class TestJudgeSummaries:
             ),
             pytest.raises(AnalysisError, match="invalid JSON"),
         ):
-            _judge_summaries("A", "B", title="Ep", judge_model="claude-opus-4-6")
+            _judge_summaries("A", "B", title="Ep", judge_model="claude-opus-4-8")
 
     def test_defaults_verdict_to_tie_when_missing(self):
         data = {
@@ -175,7 +175,7 @@ class TestJudgeSummaries:
             "pidcast.providers.claude_provider.run_claude_subprocess",
             return_value=json.dumps(data),
         ):
-            _, _, verdict, _ = _judge_summaries("A", "B", title="Ep", judge_model="claude-opus-4-6")
+            _, _, verdict, _ = _judge_summaries("A", "B", title="Ep", judge_model="claude-opus-4-8")
 
         assert verdict == "tie"
 


### PR DESCRIPTION
## Summary

- **`pidcast history`**: new command listing the last N transcription runs (date, title, provider, duration, status, transcript path) by reading the existing unified run-history store. Handles legacy/sparse run records without crashing (verified against real, non-uniformly-shaped history data on this machine).
- **Groq JSON-mode reliability fix**: GPT-OSS 120B/20B were frequently rejected by Groq's server-side JSON validation under the old loose `json_object` mode, forcing analysis down the fallback chain to a much weaker model and producing noticeably shallower summaries. Switches to Groq's strict `json_schema` structured-outputs mode on the two models confirmed to support it (live-verified against the exact prompt/transcript that was failing - now succeeds on the first call, at lower cost than the previous fallback). Also fixes a mislabeled "Rate limit on X" log line that fired for any fallback advancement regardless of the real cause, and drops `groq/compound` from the automatic fallback chain since it has a hidden per-request payload ceiling unsuited to this workload.
- **Claude model ID refresh**: updates model IDs and pricing to the current catalog (pre-existing commit on this branch).

## User-facing impact

- Users can now run `pidcast history -n 20` to quickly see recent jobs and where transcripts landed, without digging through the filesystem.
- Analysis quality improves for users on the default Groq provider: the best/cheapest model (GPT-OSS 120B) now reliably completes analysis instead of silently degrading to a weaker fallback model on a recurring basis.
- Log output during analysis is more accurate: a payload-too-large error is no longer mislabeled as a rate limit, and `--verbose` now surfaces the real Groq error detail instead of only a generic warning.

## Test plan

- [x] `uv run pytest tests/` - 486 passed, 2 pre-existing skips
- [x] `uv run ruff check src/` - clean
- [x] Live smoke test: re-ran analysis on the transcript that originally triggered the JSON-mode bug; confirmed GPT-OSS 120B now succeeds on the first call with no `json_validate_failed`, at lower cost than the previous Llama 3.3 70B fallback
- [x] `pidcast history` manually verified against real, existing `runs.json` (375 entries, mixed legacy/full-shape records) and the plain-text fallback path (rich uninstalled)